### PR TITLE
Use trixie as fallback for sid/forky/experimental Debian codenames

### DIFF
--- a/desktop.sh
+++ b/desktop.sh
@@ -589,10 +589,10 @@ step_3() {
             sudo add-apt-repository ppa:ondrej/php -y
         elif $IS_DEBIAN; then
             echo "Using Debian Sury Strategy..."
-            # Sury repo supports Debian stable releases; fall back to bookworm for unsupported codenames
-            PHP_CODENAME="$DISTRO_CODENAME"
+            # Sury repo may not support bleeding-edge codenames; fall back to trixie (current stable)
             case "$DISTRO_CODENAME" in
-                trixie|forky|sid|experimental) PHP_CODENAME="bookworm" ;;
+                trixie|forky|sid|experimental) PHP_CODENAME="trixie" ;;
+                *) PHP_CODENAME="bookworm" ;;
             esac
             install_key "https://packages.sury.org/php/apt.gpg" "/etc/apt/keyrings/php.gpg"
             echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $PHP_CODENAME main" | sudo tee /etc/apt/sources.list.d/php.list


### PR DESCRIPTION
- Problem: sid/forky/experimental codenames were not recognized on Debian 13
- Fix: added trixie as fallback for these codenames
- Fixed: incompatible PHP 8.4 dependencies on Trixie
- Tested on: Debian Bookworm and Debian Trixie ✅

<img width="692" height="617" alt="Captura de tela de 2026-03-19 00-49-00" src="https://github.com/user-attachments/assets/efe0ccec-71a6-4304-88c0-ea578b51a69e" />

<img width="674" height="162" alt="Captura de tela de 2026-03-19 16-18-34" src="https://github.com/user-attachments/assets/3621fd8d-6d22-4282-ba72-71cfb888a2d6" />

