### PR TITLE
feat: optional .NET SDK install (Desktop & Server)

### DIFF
--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -16,7 +16,7 @@ Ao criar ou editar QUALQUER arquivo `.md`, você DEVE seguir estas regras para e
         ```markdown
         # Título do Guia
         
-        > Descrição curta — v0.41.6
+        > Descrição curta — v0.41.7
         ```
 2.  **Hierarquia de Títulos:** Use `#` para H1, `##` para H2, etc. Nunca pule níveis (ex: não pule de H1 para H3).
 3.  **Tabelas:** Alinhamento obrigatório com pipes `|` e linha separadora `|---|---|`.

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -16,7 +16,7 @@ Ao criar ou editar QUALQUER arquivo `.md`, você DEVE seguir estas regras para e
         ```markdown
         # Título do Guia
         
-        > Descrição curta — v0.41.9
+        > Descrição curta — v0.41.7
         ```
 2.  **Hierarquia de Títulos:** Use `#` para H1, `##` para H2, etc. Nunca pule níveis (ex: não pule de H1 para H3).
 3.  **Tabelas:** Alinhamento obrigatório com pipes `|` e linha separadora `|---|---|`.

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -16,7 +16,7 @@ Ao criar ou editar QUALQUER arquivo `.md`, você DEVE seguir estas regras para e
         ```markdown
         # Título do Guia
         
-        > Descrição curta — v0.41.7
+        > Descrição curta — v0.41.8
         ```
 2.  **Hierarquia de Títulos:** Use `#` para H1, `##` para H2, etc. Nunca pule níveis (ex: não pule de H1 para H3).
 3.  **Tabelas:** Alinhamento obrigatório com pipes `|` e linha separadora `|---|---|`.

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -16,7 +16,7 @@ Ao criar ou editar QUALQUER arquivo `.md`, você DEVE seguir estas regras para e
         ```markdown
         # Título do Guia
         
-        > Descrição curta — v0.41.8
+        > Descrição curta — v0.41.9
         ```
 2.  **Hierarquia de Títulos:** Use `#` para H1, `##` para H2, etc. Nunca pule níveis (ex: não pule de H1 para H3).
 3.  **Tabelas:** Alinhamento obrigatório com pipes `|` e linha separadora `|---|---|`.

--- a/.claude/skills/make-changelog/SKILL.md
+++ b/.claude/skills/make-changelog/SKILL.md
@@ -27,7 +27,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 ## 3. Formatação e Estilo
 
 - **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD).
-  *   *Exemplo:* `## [v0.41.8] - 2026-04-05`
+  *   *Exemplo:* `## [v0.41.9] - 2026-04-05`
 - **Mensagens:**
   *   Use o tempo verbal no passado (ex: "Added", "Improved", "Fixed").
   *   Seja conciso mas específico (ex: em vez de "Update PATH", use "Improved PATH handling for Ruby and Composer").

--- a/.claude/skills/make-changelog/SKILL.md
+++ b/.claude/skills/make-changelog/SKILL.md
@@ -27,7 +27,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 ## 3. Formatação e Estilo
 
 - **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD).
-  *   *Exemplo:* `## [v0.41.6] - 2026-04-05`
+  *   *Exemplo:* `## [v0.41.7] - 2026-04-05`
 - **Mensagens:**
   *   Use o tempo verbal no passado (ex: "Added", "Improved", "Fixed").
   *   Seja conciso mas específico (ex: em vez de "Update PATH", use "Improved PATH handling for Ruby and Composer").

--- a/.claude/skills/make-changelog/SKILL.md
+++ b/.claude/skills/make-changelog/SKILL.md
@@ -27,7 +27,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 ## 3. Formatação e Estilo
 
 - **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD).
-  *   *Exemplo:* `## [v0.41.9] - 2026-04-05`
+  *   *Exemplo:* `## [v0.41.7] - 2026-04-05`
 - **Mensagens:**
   *   Use o tempo verbal no passado (ex: "Added", "Improved", "Fixed").
   *   Seja conciso mas específico (ex: em vez de "Update PATH", use "Improved PATH handling for Ruby and Composer").

--- a/.claude/skills/make-changelog/SKILL.md
+++ b/.claude/skills/make-changelog/SKILL.md
@@ -27,7 +27,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 ## 3. Formatação e Estilo
 
 - **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD).
-  *   *Exemplo:* `## [v0.41.7] - 2026-04-05`
+  *   *Exemplo:* `## [v0.41.8] - 2026-04-05`
 - **Mensagens:**
   *   Use o tempo verbal no passado (ex: "Added", "Improved", "Fixed").
   *   Seja conciso mas específico (ex: em vez de "Update PATH", use "Improved PATH handling for Ruby and Composer").

--- a/.gemini/skills/documentation/SKILL.md
+++ b/.gemini/skills/documentation/SKILL.md
@@ -11,7 +11,7 @@ Este guia define o padrão ouro para manter a documentação do SetupVibe sincro
 
 Ao criar ou editar QUALQUER arquivo `.md`, você DEVE invocar a skill **`markdown-format`** para garantir a conformidade com as regras do projeto:
 
-1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.6`.
+1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.7`.
 2.  **Linting Delegado:** Todas as regras de títulos, tabelas, code blocks, links, listas e espaçamentos são gerenciadas pela skill `markdown-format`. **Não ignore seus avisos**.
 3.  **Linting Final:** Após criar ou editar o arquivo, processe-o com a skill `markdown-format` para validar conformidade.
 

--- a/.gemini/skills/documentation/SKILL.md
+++ b/.gemini/skills/documentation/SKILL.md
@@ -11,7 +11,7 @@ Este guia define o padrão ouro para manter a documentação do SetupVibe sincro
 
 Ao criar ou editar QUALQUER arquivo `.md`, você DEVE invocar a skill **`markdown-format`** para garantir a conformidade com as regras do projeto:
 
-1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.7`.
+1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.8`.
 2.  **Linting Delegado:** Todas as regras de títulos, tabelas, code blocks, links, listas e espaçamentos são gerenciadas pela skill `markdown-format`. **Não ignore seus avisos**.
 3.  **Linting Final:** Após criar ou editar o arquivo, processe-o com a skill `markdown-format` para validar conformidade.
 

--- a/.gemini/skills/documentation/SKILL.md
+++ b/.gemini/skills/documentation/SKILL.md
@@ -11,7 +11,7 @@ Este guia define o padrão ouro para manter a documentação do SetupVibe sincro
 
 Ao criar ou editar QUALQUER arquivo `.md`, você DEVE invocar a skill **`markdown-format`** para garantir a conformidade com as regras do projeto:
 
-1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.8`.
+1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.9`.
 2.  **Linting Delegado:** Todas as regras de títulos, tabelas, code blocks, links, listas e espaçamentos são gerenciadas pela skill `markdown-format`. **Não ignore seus avisos**.
 3.  **Linting Final:** Após criar ou editar o arquivo, processe-o com a skill `markdown-format` para validar conformidade.
 

--- a/.gemini/skills/documentation/SKILL.md
+++ b/.gemini/skills/documentation/SKILL.md
@@ -11,7 +11,7 @@ Este guia define o padrão ouro para manter a documentação do SetupVibe sincro
 
 Ao criar ou editar QUALQUER arquivo `.md`, você DEVE invocar a skill **`markdown-format`** para garantir a conformidade com as regras do projeto:
 
-1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.9`.
+1.  **Cabeçalho Padrão:** Começar com H1 seguido de blockquote com a versão. Ex: `> Descrição curta — v0.41.7`.
 2.  **Linting Delegado:** Todas as regras de títulos, tabelas, code blocks, links, listas e espaçamentos são gerenciadas pela skill `markdown-format`. **Não ignore seus avisos**.
 3.  **Linting Final:** Após criar ou editar o arquivo, processe-o com a skill `markdown-format` para validar conformidade.
 

--- a/.gemini/skills/make-changelog/SKILL.md
+++ b/.gemini/skills/make-changelog/SKILL.md
@@ -28,7 +28,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 
 Para garantir a perfeição visual e técnica do `CHANGELOG.md`:
 
-- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.8] - 2026-04-05`.
+- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.9] - 2026-04-05`.
 - **Mensagens:** Use bullet points `-` e tempo verbal no passado (Added, Improved, Fixed).
 - **Linting:** Após gerar o conteúdo, **você deve invocar a skill `markdown-format`** para aplicar o alinhamento de tabelas, espaçamento de blocos e o rodapé obrigatório.
 

--- a/.gemini/skills/make-changelog/SKILL.md
+++ b/.gemini/skills/make-changelog/SKILL.md
@@ -28,7 +28,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 
 Para garantir a perfeição visual e técnica do `CHANGELOG.md`:
 
-- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.6] - 2026-04-05`.
+- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.7] - 2026-04-05`.
 - **Mensagens:** Use bullet points `-` e tempo verbal no passado (Added, Improved, Fixed).
 - **Linting:** Após gerar o conteúdo, **você deve invocar a skill `markdown-format`** para aplicar o alinhamento de tabelas, espaçamento de blocos e o rodapé obrigatório.
 

--- a/.gemini/skills/make-changelog/SKILL.md
+++ b/.gemini/skills/make-changelog/SKILL.md
@@ -28,7 +28,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 
 Para garantir a perfeição visual e técnica do `CHANGELOG.md`:
 
-- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.7] - 2026-04-05`.
+- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.8] - 2026-04-05`.
 - **Mensagens:** Use bullet points `-` e tempo verbal no passado (Added, Improved, Fixed).
 - **Linting:** Após gerar o conteúdo, **você deve invocar a skill `markdown-format`** para aplicar o alinhamento de tabelas, espaçamento de blocos e o rodapé obrigatório.
 

--- a/.gemini/skills/make-changelog/SKILL.md
+++ b/.gemini/skills/make-changelog/SKILL.md
@@ -28,7 +28,7 @@ Distribua as mudanças nas seções padronizadas do "Keep a Changelog":
 
 Para garantir a perfeição visual e técnica do `CHANGELOG.md`:
 
-- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.9] - 2026-04-05`.
+- **Cabeçalho da Versão:** Use H2 com colchetes, versão e data (AAAA-MM-DD). Ex: `## [v0.41.7] - 2026-04-05`.
 - **Mensagens:** Use bullet points `-` e tempo verbal no passado (Added, Improved, Fixed).
 - **Linting:** Após gerar o conteúdo, **você deve invocar a skill `markdown-format`** para aplicar o alinhamento de tabelas, espaçamento de blocos e o rodapé obrigatório.
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must use LF so bash on Linux/macOS never sees stray CR (avoids $'\r': command not found).
+*.sh text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides instructions and context for AI coding agents (OpenAI Codex, 
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.7). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.8). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides instructions and context for AI coding agents (OpenAI Codex, 
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.9). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.7). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides instructions and context for AI coding agents (OpenAI Codex, 
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.6). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.7). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 
@@ -22,6 +22,10 @@ bash server.sh
 
 # Or via curl (canonical usage)
 curl -sSL desktop.setupvibe.dev | bash
+
+# Optional .NET SDK (default .NET 10; also --install-dotnet=8|9|10)
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 ```
 
 To test changes to a script, run it directly on a target machine or VM.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides instructions and context for AI coding agents (OpenAI Codex, 
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.8). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.9). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **SetupVibe** are documented in this file.
 
 ---
 
+## [v0.41.9] - 2026-04-18
+
+### Fixed
+
+- **.NET roadmap label:** Improved detection of an existing `dotnet` installation for the interactive roadmap and final summary (try `/usr/bin/dotnet`, `/usr/share/dotnet/dotnet`, and `~/.dotnet/dotnet`; use `bash -c` with `PATH` including `snap/bin` instead of relying on `bash -l`).
+
+---
+
 ## [v0.41.8] - 2026-04-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to **SetupVibe** are documented in this file.
 
 ---
 
+## [v0.41.8] - 2026-04-18
+
+### Changed
+
+- Roadmap and installation summary now show **.NET** in the relevant step title when `--install-dotnet` is used, or when an existing **.NET SDK** is detected (Desktop step 5; Server **AI CLI Tools** step).
+
+---
+
 ## [v0.41.7] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to **SetupVibe** are documented in this file.
 
 ---
 
+## [v0.41.7] - 2026-04-18
+
+### Added
+
+- Optional **.NET SDK** installation via `--install-dotnet` (defaults to **.NET 10** LTS channel) and `--install-dotnet=8|9|10` on both **Desktop** and **Server** editions. Linux uses the Microsoft APT repository when available, with fallback to the official `dotnet-install.sh` script; macOS (Desktop) uses `dotnet-install.sh` under `~/.dotnet`.
+- Shell PATH support for user-local .NET (`DOTNET_ROOT`, `~/.dotnet`, `~/.dotnet/tools`) in `conf/zshrc-*.zsh` when `~/.dotnet` exists.
+
+---
+
 ## [v0.41.6] - 2026-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,16 @@ All notable changes to **SetupVibe** are documented in this file.
 
 ---
 
-## [v0.41.9] - 2026-04-18
-
-### Fixed
-
-- **.NET roadmap label:** Improved detection of an existing `dotnet` installation for the interactive roadmap and final summary (try `/usr/bin/dotnet`, `/usr/share/dotnet/dotnet`, and `~/.dotnet/dotnet`; use `bash -c` with `PATH` including `snap/bin` instead of relying on `bash -l`).
-
----
-
-## [v0.41.8] - 2026-04-18
-
-### Changed
-
-- Roadmap and installation summary now show **.NET** in the relevant step title when `--install-dotnet` is used, or when an existing **.NET SDK** is detected (Desktop step 5; Server **AI CLI Tools** step).
-
----
-
 ## [v0.41.7] - 2026-04-18
 
 ### Added
 
 - Optional **.NET SDK** installation via `--install-dotnet` (defaults to **.NET 10** LTS channel) and `--install-dotnet=8|9|10` on both **Desktop** and **Server** editions. Linux uses the Microsoft APT repository when available, with fallback to the official `dotnet-install.sh` script; macOS (Desktop) uses `dotnet-install.sh` under `~/.dotnet`.
 - Shell PATH support for user-local .NET (`DOTNET_ROOT`, `~/.dotnet`, `~/.dotnet/tools`) in `conf/zshrc-*.zsh` when `~/.dotnet` exists.
+
+### Changed
+
+- Roadmap and installation summary show **.NET** in the relevant step title when `--install-dotnet` is used, or when an existing **.NET SDK** is detected (Desktop step 5; Server **AI CLI Tools** step). Detection checks `~/.dotnet/dotnet`, `/usr/bin/dotnet`, `/usr/share/dotnet/dotnet`, and uses `bash -c` with `PATH` including `snap/bin` where needed.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.8). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.9). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.6). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.7). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 
@@ -22,6 +22,10 @@ bash server.sh
 
 # Or via curl (canonical usage)
 curl -sSL desktop.setupvibe.dev | bash
+
+# Optional .NET SDK (default .NET 10; also --install-dotnet=8|9|10)
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 ```
 
 To test changes to a script, run it directly on a target machine or VM.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.7). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.8). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-**SetupVibe** is a cross-platform automated development environment setup script (v0.41.9). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup script (v0.41.7). It installs and configures a complete developer toolkit in one command, supporting macOS 12+ and Linux (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 There are two editions:
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@ This file provides instructions and context for Gemini CLI when working with the
 
 ## Project Overview
 
-**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.6). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.7). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 The project consists of two primary editions:
 
@@ -42,6 +42,10 @@ bash server.sh
 
 # Canonical usage (from README)
 curl -sSL desktop.setupvibe.dev | bash
+
+# Optional .NET SDK (default .NET 10; also --install-dotnet=8|9|10)
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 ```
 
 ### Testing Changes

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@ This file provides instructions and context for Gemini CLI when working with the
 
 ## Project Overview
 
-**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.9). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.7). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 The project consists of two primary editions:
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@ This file provides instructions and context for Gemini CLI when working with the
 
 ## Project Overview
 
-**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.7). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.8). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 The project consists of two primary editions:
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@ This file provides instructions and context for Gemini CLI when working with the
 
 ## Project Overview
 
-**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.8). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
+**SetupVibe** is a cross-platform automated development environment setup tool (v0.41.9). It streamlines the installation and configuration of a complete developer toolkit for macOS (12+) and major Linux distributions (Ubuntu 24.04+, Debian 12+, Zorin OS 18+).
 
 The project consists of two primary editions:
 

--- a/MARKDOWN.md
+++ b/MARKDOWN.md
@@ -394,7 +394,7 @@ Documentation files in `docs/` should begin with an H1 and a blockquote describi
 ```markdown
 # Guide Title
 
-> Short description — v0.41.9
+> Short description — v0.41.7
 ```
 
 ---

--- a/MARKDOWN.md
+++ b/MARKDOWN.md
@@ -394,7 +394,7 @@ Documentation files in `docs/` should begin with an H1 and a blockquote describi
 ```markdown
 # Guide Title
 
-> Short description — v0.41.6
+> Short description — v0.41.7
 ```
 
 ---

--- a/MARKDOWN.md
+++ b/MARKDOWN.md
@@ -394,7 +394,7 @@ Documentation files in `docs/` should begin with an H1 and a blockquote describi
 ```markdown
 # Guide Title
 
-> Short description — v0.41.7
+> Short description — v0.41.8
 ```
 
 ---

--- a/MARKDOWN.md
+++ b/MARKDOWN.md
@@ -394,7 +394,7 @@ Documentation files in `docs/` should begin with an H1 and a blockquote describi
 ```markdown
 # Guide Title
 
-> Short description — v0.41.8
+> Short description — v0.41.9
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SetupVibe
 
-> The ultimate cross-platform development environment setup script — v0.41.9
+> The ultimate cross-platform development environment setup script — v0.41.7
 
 Installs and configures a complete development stack in one command, supporting macOS and major Linux distributions.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SetupVibe
 
-> The ultimate cross-platform development environment setup script — v0.41.6
+> The ultimate cross-platform development environment setup script — v0.41.7
 
 Installs and configures a complete development stack in one command, supporting macOS and major Linux distributions.
 
@@ -40,6 +40,14 @@ To initialize Docker Swarm automatically after setup:
 
 ```bash
 curl -sSL server.setupvibe.dev | bash -s -- --manager
+```
+
+Optional **.NET SDK** (default **.NET 10**; use `--install-dotnet=8` or `=9` for other supported majors):
+
+```bash
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SetupVibe
 
-> The ultimate cross-platform development environment setup script — v0.41.8
+> The ultimate cross-platform development environment setup script — v0.41.9
 
 Installs and configures a complete development stack in one command, supporting macOS and major Linux distributions.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SetupVibe
 
-> The ultimate cross-platform development environment setup script — v0.41.7
+> The ultimate cross-platform development environment setup script — v0.41.8
 
 Installs and configures a complete development stack in one command, supporting macOS and major Linux distributions.
 

--- a/conf/zshrc-linux.zsh
+++ b/conf/zshrc-linux.zsh
@@ -7,6 +7,10 @@ elif [ -f "$HOME/.linuxbrew/bin/brew" ]; then
 fi
 
 # Define PATHs before loading plugins so they can find the tools
+if [[ -d "$HOME/.dotnet" ]]; then
+    export DOTNET_ROOT="$HOME/.dotnet"
+    export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+fi
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.npm-global/bin:$PATH"
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/conf/zshrc-macos.zsh
+++ b/conf/zshrc-macos.zsh
@@ -7,6 +7,10 @@ elif [[ -f "/usr/local/bin/brew" ]]; then
 fi
 
 # Define PATHs before loading plugins so they can find the tools
+if [[ -d "$HOME/.dotnet" ]]; then
+    export DOTNET_ROOT="$HOME/.dotnet"
+    export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+fi
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.cargo/bin:$PATH"
 export PATH="$HOME/.config/composer/vendor/bin:$PATH"

--- a/conf/zshrc-server.zsh
+++ b/conf/zshrc-server.zsh
@@ -6,6 +6,10 @@ elif [ -f "$HOME/.linuxbrew/bin/brew" ]; then
     eval "$($HOME/.linuxbrew/bin/brew shellenv)"
 fi
 
+if [[ -d "$HOME/.dotnet" ]]; then
+    export DOTNET_ROOT="$HOME/.dotnet"
+    export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+fi
 export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"

--- a/desktop.sh
+++ b/desktop.sh
@@ -25,10 +25,38 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.6"
+VERSION="0.41.7"
 INSTALL_URL="https://desktop.setupvibe.dev"
 
+# --- ARGUMENT PARSING ---
+INSTALL_DOTNET=false
+DOTNET_MAJOR=""
+for arg in "$@"; do
+    case "$arg" in
+        --install-dotnet)
+            INSTALL_DOTNET=true
+            DOTNET_MAJOR="10"
+            ;;
+        --install-dotnet=*)
+            INSTALL_DOTNET=true
+            DOTNET_MAJOR="${arg#*=}"
+            ;;
+    esac
+done
+if $INSTALL_DOTNET; then
+    case "$DOTNET_MAJOR" in
+        8|9|10) ;;
+        *)
+            echo -e "${RED}Error: --install-dotnet requires major version 8, 9, or 10 (e.g. --install-dotnet=9).${NC}"
+            exit 1
+            ;;
+    esac
+fi
+
 echo -e "${CYAN}SetupVibe Desktop v${VERSION}${NC}"
+if $INSTALL_DOTNET; then
+    echo -e "${YELLOW}  → .NET SDK ${DOTNET_MAJOR}.x install requested${NC}"
+fi
 echo ""
 
 # --- ENVIRONMENT ---
@@ -113,7 +141,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     
     # If we have errors in APT, we try to fix them by removing potentially broken lists managed by this script
     # This prevents the error you saw: signature verification failed because keys were deleted
-    sys_do grep -rl 'docker\|nodesource\|charm\.sh\|cli\.github\|sury\|ondrej\|ansible\|codeiumdata\|windsurf\|antigravity\|pkg\.dev' \
+    sys_do grep -rl 'docker\|nodesource\|charm\.sh\|cli\.github\|sury\|ondrej\|ansible\|codeiumdata\|windsurf\|antigravity\|pkg\.dev\|packages\.microsoft' \
         /etc/apt/sources.list.d/ 2>/dev/null | xargs -I {} sys_do rm -f "{}" 2>/dev/null || true
 
     sys_do apt-get update -y -qq
@@ -468,6 +496,81 @@ safe_download() {
 }
 
 
+# Install Microsoft .NET SDK (optional; see --install-dotnet / --install-dotnet=MAJOR)
+_install_dotnet_via_install_script() {
+    local inst_dir="$REAL_HOME/.dotnet"
+    echo -e "${YELLOW}Installing .NET SDK via dotnet-install.sh (channel ${DOTNET_MAJOR}.0) → $inst_dir${NC}"
+    user_do mkdir -p "$inst_dir"
+    local script
+    script=$(mktemp /tmp/dotnet-install.XXXXXX.sh)
+    if ! curl -fsSL "https://dot.net/v1/dotnet-install.sh" -o "$script"; then
+        echo -e "${RED}✘ Failed to download dotnet-install.sh${NC}"
+        rm -f "$script"
+        return 1
+    fi
+    chmod +x "$script"
+    if user_do bash "$script" --channel "${DOTNET_MAJOR}.0" --install-dir "$inst_dir"; then
+        rm -f "$script"
+        if user_do test -x "$inst_dir/dotnet"; then
+            echo -e "${GREEN}✔ .NET SDK installed to $inst_dir${NC}"
+            return 0
+        fi
+    fi
+    rm -f "$script"
+    echo -e "${RED}✘ .NET SDK installation failed.${NC}"
+    return 1
+}
+
+install_dotnet_sdk() {
+    echo ""
+    echo -e "${BLUE}========================================================${NC}"
+    echo -e "${BOLD}▶ .NET SDK (${DOTNET_MAJOR}.x)${NC}"
+    echo -e "${BLUE}========================================================${NC}"
+    local sdk_pkg="dotnet-sdk-${DOTNET_MAJOR}.0"
+
+    if $IS_MACOS; then
+        _install_dotnet_via_install_script
+        return $?
+    fi
+
+    if $IS_LINUX && ( $IS_UBUNTU || $IS_DEBIAN ); then
+        local msdeb=""
+        local ubver=""
+        local dver=""
+        if $IS_UBUNTU; then
+            ubver=$(lsb_release -rs 2>/dev/null)
+            [[ -n "$ubver" ]] && msdeb="https://packages.microsoft.com/config/ubuntu/${ubver}/packages-microsoft-prod.deb"
+        else
+            dver=$(grep -E '^VERSION_ID=' /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"')
+            [[ -n "$dver" ]] && msdeb="https://packages.microsoft.com/config/debian/${dver}/packages-microsoft-prod.deb"
+        fi
+
+        if [[ -n "$msdeb" ]]; then
+            local tmpdeb
+            tmpdeb=$(mktemp /tmp/msprodXXXXXX.deb)
+            echo -e "${YELLOW}Adding Microsoft package repository...${NC}"
+            if curl -fsSL "$msdeb" -o "$tmpdeb" && sys_do dpkg -i "$tmpdeb"; then
+                rm -f "$tmpdeb"
+                sys_do apt-get install -f -y -qq 2>/dev/null || true
+                sys_do apt-get update -qq
+                if sys_do apt-get install -y "$sdk_pkg"; then
+                    echo -e "${GREEN}✔ .NET SDK installed via APT (${sdk_pkg}).${NC}"
+                    command -v dotnet >/dev/null 2>&1 && user_do dotnet --version
+                    return 0
+                fi
+            else
+                rm -f "$tmpdeb"
+            fi
+            echo -e "${YELLOW}⚠ APT install failed or package unavailable — trying dotnet-install.sh...${NC}"
+        fi
+    else
+        echo -e "${YELLOW}⚠ Non-Debian/Ubuntu Linux — using dotnet-install.sh...${NC}"
+    fi
+
+    _install_dotnet_via_install_script
+}
+
+
 # --- INSTALLATION STEPS ---
 
 
@@ -735,6 +838,10 @@ step_5() {
         brew_cmd install cronboard
 
         cron_ensure
+
+        if $INSTALL_DOTNET; then
+            install_dotnet_sdk || echo -e "${YELLOW}⚠ .NET SDK step finished with warnings.${NC}"
+        fi
     else
         echo "Setup Python..."
         sys_do apt-get install -y python3 python3-pip python3-venv python-is-python3
@@ -771,6 +878,10 @@ step_5() {
         fi
 
         cron_ensure
+
+        if $INSTALL_DOTNET; then
+            install_dotnet_sdk || echo -e "${YELLOW}⚠ .NET SDK step finished with warnings.${NC}"
+        fi
     fi
 }
 

--- a/desktop.sh
+++ b/desktop.sh
@@ -25,7 +25,7 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.8"
+VERSION="0.41.9"
 INSTALL_URL="https://desktop.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---
@@ -1327,11 +1327,16 @@ update_steps_dotnet_labels() {
         return
     fi
     local dver=""
-    if [[ -x "$REAL_HOME/.dotnet/dotnet" ]]; then
-        dver=$(user_do env HOME="$REAL_HOME" PATH="$REAL_HOME/.dotnet:${PATH}" "$REAL_HOME/.dotnet/dotnet" --version 2>/dev/null | head -1 | tr -d '\r' || true)
-    fi
-    if [[ -z "$dver" ]] && user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; command -v dotnet' &>/dev/null; then
-        dver=$(user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; dotnet --version 2>/dev/null' | head -1 | tr -d '\r' || true)
+    local cand
+    # Try common paths (dotnet-install ~/.dotnet, Microsoft APT /usr/bin, shared root)
+    for cand in "$REAL_HOME/.dotnet/dotnet" "/usr/bin/dotnet" "/usr/share/dotnet/dotnet"; do
+        [[ -e "$cand" ]] || continue
+        dver=$(user_do env HOME="$REAL_HOME" PATH="$(dirname "$cand"):/usr/local/bin:/usr/bin:${PATH}" "$cand" --version 2>/dev/null | head -1 | tr -d '\r' || true)
+        [[ -n "$dver" ]] && break
+    done
+    # Non-login shell with PATH typical for dotnet-install, snap, and package installs
+    if [[ -z "$dver" ]]; then
+        dver=$(user_do bash -c 'export PATH="$HOME/.dotnet:/snap/bin:/usr/local/bin:/usr/bin:$PATH"; command -v dotnet >/dev/null 2>&1 && dotnet --version' 2>/dev/null | head -1 | tr -d '\r' || true)
     fi
     if [[ -z "$dver" ]] && command -v dotnet &>/dev/null; then
         dver=$(dotnet --version 2>/dev/null | head -1 | tr -d '\r' || true)

--- a/desktop.sh
+++ b/desktop.sh
@@ -25,7 +25,7 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.7"
+VERSION="0.41.8"
 INSTALL_URL="https://desktop.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---
@@ -1319,9 +1319,33 @@ step_14() {
 }
 
 
+# Adjust roadmap/summary labels when .NET install is requested or already present
+update_steps_dotnet_labels() {
+    local base="Languages (Go, Rust, Python + uv)"
+    if $INSTALL_DOTNET; then
+        STEPS[4]="${base}; .NET SDK ${DOTNET_MAJOR}.x"
+        return
+    fi
+    local dver=""
+    if [[ -x "$REAL_HOME/.dotnet/dotnet" ]]; then
+        dver=$(user_do env HOME="$REAL_HOME" PATH="$REAL_HOME/.dotnet:${PATH}" "$REAL_HOME/.dotnet/dotnet" --version 2>/dev/null | head -1 | tr -d '\r' || true)
+    fi
+    if [[ -z "$dver" ]] && user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; command -v dotnet' &>/dev/null; then
+        dver=$(user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; dotnet --version 2>/dev/null' | head -1 | tr -d '\r' || true)
+    fi
+    if [[ -z "$dver" ]] && command -v dotnet &>/dev/null; then
+        dver=$(dotnet --version 2>/dev/null | head -1 | tr -d '\r' || true)
+    fi
+    if [[ -n "$dver" ]]; then
+        STEPS[4]="${base} [.NET present: ${dver}]"
+    fi
+}
+
+
 # --- MAIN EXECUTION ---
 
 
+update_steps_dotnet_labels
 show_roadmap_and_wait
 configure_git_interactive
 

--- a/desktop.sh
+++ b/desktop.sh
@@ -25,7 +25,7 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.9"
+VERSION="0.41.7"
 INSTALL_URL="https://desktop.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # SetupVibe Documentation
 
-> Automated development environment setup — v0.41.7
+> Automated development environment setup — v0.41.8
 
-SetupVibe transforms any fresh machine into a fully configured development workspace in one command. It supports two editions depending on your target:
+SetupVibe transforms any fresh machine into a fully configured development workspace in one command. It supports two editions depending on your target. When you pass `--install-dotnet` or a .NET SDK is already detected, the interactive roadmap and final installation summary include **.NET** in the relevant step title (Desktop: Languages step; Server: AI CLI Tools).
 
 | Edition     | Script       | Platforms                                            | Guides                                                                                                               |
 | ----------- | ------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SetupVibe Documentation
 
-> Automated development environment setup — v0.41.6
+> Automated development environment setup — v0.41.7
 
 SetupVibe transforms any fresh machine into a fully configured development workspace in one command. It supports two editions depending on your target:
 
@@ -29,6 +29,19 @@ To initialize Docker Swarm automatically after setup:
 curl -sSL server.setupvibe.dev | bash -s -- --manager
 ```
 
+To install the **.NET SDK** (default **.NET 10**; use `=8` or `=9` for other supported majors):
+
+```bash
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet
+```
+
+You can combine flags on the Server edition (order does not matter), for example:
+
+```bash
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
+```
+
 ## Edition Comparison
 
 | Feature                               | Desktop        | Server  |
@@ -51,6 +64,7 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager
 | AI CLI tools                          | ✔              | ✔       |
 | PM2 auto-startup                      | ✔              | ✗       |
 | Docker Swarm Manager (`--manager`)    | ✗              | ✔       |
+| Optional .NET SDK (`--install-dotnet`) | ✔              | ✔       |
 
 ## Specialized Guides
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SetupVibe Documentation
 
-> Automated development environment setup — v0.41.8
+> Automated development environment setup — v0.41.9
 
 SetupVibe transforms any fresh machine into a fully configured development workspace in one command. It supports two editions depending on your target. When you pass `--install-dotnet` or a .NET SDK is already detected, the interactive roadmap and final installation summary include **.NET** in the relevant step title (Desktop: Languages step; Server: AI CLI Tools).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SetupVibe Documentation
 
-> Automated development environment setup — v0.41.9
+> Automated development environment setup — v0.41.7
 
 SetupVibe transforms any fresh machine into a fully configured development workspace in one command. It supports two editions depending on your target. When you pass `--install-dotnet` or a .NET SDK is already detected, the interactive roadmap and final installation summary include **.NET** in the relevant step title (Desktop: Languages step; Server: AI CLI Tools).
 

--- a/docs/desktop/README.md
+++ b/docs/desktop/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.7
+> Cross-platform development environment setup — v0.41.8
 
 Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: languages (PHP, Ruby, Go, Rust, Python, Node.js; optional .NET SDK via `--install-dotnet`), DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
 

--- a/docs/desktop/README.md
+++ b/docs/desktop/README.md
@@ -1,8 +1,8 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.6
+> Cross-platform development environment setup — v0.41.7
 
-Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: languages (PHP, Ruby, Go, Rust, Python, Node.js), DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
+Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: languages (PHP, Ruby, Go, Rust, Python, Node.js; optional .NET SDK via `--install-dotnet`), DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
 
 ## Documentation
 

--- a/docs/desktop/README.md
+++ b/docs/desktop/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.9
+> Cross-platform development environment setup — v0.41.7
 
 Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: languages (PHP, Ruby, Go, Rust, Python, Node.js; optional .NET SDK via `--install-dotnet`), DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
 

--- a/docs/desktop/README.md
+++ b/docs/desktop/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.8
+> Cross-platform development environment setup — v0.41.9
 
 Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: languages (PHP, Ruby, Go, Rust, Python, Node.js; optional .NET SDK via `--install-dotnet`), DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
 

--- a/docs/desktop/en/README.md
+++ b/docs/desktop/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.6
+> Cross-platform development environment setup — v0.41.7
 
 Installs and configures a complete developer stack in one command. Supports macOS and major Linux distributions.
 
@@ -27,6 +27,14 @@ Or locally:
 
 ```bash
 bash desktop.sh
+```
+
+Optional **.NET SDK** (default **.NET 10**; supported majors `8`, `9`, `10`):
+
+```bash
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
+bash desktop.sh --install-dotnet=10
 ```
 
 The script shows an interactive roadmap and asks for confirmation before starting. It also prompts to configure Git identity if not already set.

--- a/docs/desktop/en/README.md
+++ b/docs/desktop/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.9
+> Cross-platform development environment setup — v0.41.7
 
 Installs and configures a complete developer stack in one command. Supports macOS and major Linux distributions.
 

--- a/docs/desktop/en/README.md
+++ b/docs/desktop/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.7
+> Cross-platform development environment setup — v0.41.8
 
 Installs and configures a complete developer stack in one command. Supports macOS and major Linux distributions.
 
@@ -37,7 +37,7 @@ curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
 bash desktop.sh --install-dotnet=10
 ```
 
-The script shows an interactive roadmap and asks for confirmation before starting. It also prompts to configure Git identity if not already set.
+The script shows an interactive roadmap and asks for confirmation before starting. If you pass `--install-dotnet` or a .NET SDK is already detected, **step 5** in the roadmap and in the final summary includes a **.NET** note. It also prompts to configure Git identity if not already set.
 
 ---
 

--- a/docs/desktop/en/README.md
+++ b/docs/desktop/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Desktop Edition
 
-> Cross-platform development environment setup — v0.41.8
+> Cross-platform development environment setup — v0.41.9
 
 Installs and configures a complete developer stack in one command. Supports macOS and major Linux distributions.
 

--- a/docs/desktop/en/SPECKIT.md
+++ b/docs/desktop/en/SPECKIT.md
@@ -1,6 +1,6 @@
 # Spec-Kit Guide
 
-> Tooling guide — v0.41.8
+> Tooling guide — v0.41.9
 
 SetupVibe installs [Spec-Kit](https://github.com/github/spec-kit) on the Desktop edition (macOS and Linux desktop) via `uv tool install specify-cli`.
 

--- a/docs/desktop/en/SPECKIT.md
+++ b/docs/desktop/en/SPECKIT.md
@@ -1,6 +1,6 @@
 # Spec-Kit Guide
 
-> Tooling guide — v0.41.7
+> Tooling guide — v0.41.8
 
 SetupVibe installs [Spec-Kit](https://github.com/github/spec-kit) on the Desktop edition (macOS and Linux desktop) via `uv tool install specify-cli`.
 

--- a/docs/desktop/en/SPECKIT.md
+++ b/docs/desktop/en/SPECKIT.md
@@ -1,6 +1,6 @@
 # Spec-Kit Guide
 
-> Tooling guide — v0.41.6
+> Tooling guide — v0.41.7
 
 SetupVibe installs [Spec-Kit](https://github.com/github/spec-kit) on the Desktop edition (macOS and Linux desktop) via `uv tool install specify-cli`.
 

--- a/docs/desktop/en/SPECKIT.md
+++ b/docs/desktop/en/SPECKIT.md
@@ -1,6 +1,6 @@
 # Spec-Kit Guide
 
-> Tooling guide — v0.41.9
+> Tooling guide — v0.41.7
 
 SetupVibe installs [Spec-Kit](https://github.com/github/spec-kit) on the Desktop edition (macOS and Linux desktop) via `uv tool install specify-cli`.
 

--- a/docs/desktop/en/cronboard.md
+++ b/docs/desktop/en/cronboard.md
@@ -1,6 +1,6 @@
 # Cronboard Guide
 >
-> Cron TUI for dashboard monitoring — v0.41.6
+> Cron TUI for dashboard monitoring — v0.41.7
 
 SetupVibe installs [Cronboard](https://github.com/antoniorodr/cronboard) to provide a terminal user interface (TUI) for managing cron tasks.
 

--- a/docs/desktop/en/cronboard.md
+++ b/docs/desktop/en/cronboard.md
@@ -1,6 +1,6 @@
 # Cronboard Guide
 >
-> Cron TUI for dashboard monitoring — v0.41.7
+> Cron TUI for dashboard monitoring — v0.41.8
 
 SetupVibe installs [Cronboard](https://github.com/antoniorodr/cronboard) to provide a terminal user interface (TUI) for managing cron tasks.
 

--- a/docs/desktop/en/cronboard.md
+++ b/docs/desktop/en/cronboard.md
@@ -1,6 +1,6 @@
 # Cronboard Guide
 >
-> Cron TUI for dashboard monitoring — v0.41.8
+> Cron TUI for dashboard monitoring — v0.41.9
 
 SetupVibe installs [Cronboard](https://github.com/antoniorodr/cronboard) to provide a terminal user interface (TUI) for managing cron tasks.
 

--- a/docs/desktop/en/cronboard.md
+++ b/docs/desktop/en/cronboard.md
@@ -1,6 +1,6 @@
 # Cronboard Guide
 >
-> Cron TUI for dashboard monitoring — v0.41.9
+> Cron TUI for dashboard monitoring — v0.41.7
 
 SetupVibe installs [Cronboard](https://github.com/antoniorodr/cronboard) to provide a terminal user interface (TUI) for managing cron tasks.
 

--- a/docs/desktop/en/pm2.md
+++ b/docs/desktop/en/pm2.md
@@ -1,6 +1,6 @@
 # PM2 Guide
 >
-> Process management guide — v0.41.6
+> Process management guide — v0.41.7
 
 SetupVibe installs [PM2](https://pm2.keymetrics.io/) globally and configures it for auto-startup on the Desktop edition.
 

--- a/docs/desktop/en/pm2.md
+++ b/docs/desktop/en/pm2.md
@@ -1,6 +1,6 @@
 # PM2 Guide
 >
-> Process management guide — v0.41.8
+> Process management guide — v0.41.9
 
 SetupVibe installs [PM2](https://pm2.keymetrics.io/) globally and configures it for auto-startup on the Desktop edition.
 

--- a/docs/desktop/en/pm2.md
+++ b/docs/desktop/en/pm2.md
@@ -1,6 +1,6 @@
 # PM2 Guide
 >
-> Process management guide — v0.41.9
+> Process management guide — v0.41.7
 
 SetupVibe installs [PM2](https://pm2.keymetrics.io/) globally and configures it for auto-startup on the Desktop edition.
 

--- a/docs/desktop/en/pm2.md
+++ b/docs/desktop/en/pm2.md
@@ -1,6 +1,6 @@
 # PM2 Guide
 >
-> Process management guide — v0.41.7
+> Process management guide — v0.41.8
 
 SetupVibe installs [PM2](https://pm2.keymetrics.io/) globally and configures it for auto-startup on the Desktop edition.
 

--- a/docs/desktop/en/tmux.md
+++ b/docs/desktop/en/tmux.md
@@ -1,6 +1,6 @@
 # Tmux Guide
 >
-> Terminal multiplexer configuration — v0.41.7
+> Terminal multiplexer configuration — v0.41.8
 
 SetupVibe installs and configures tmux with [TPM](https://github.com/tmux-plugins/tpm) and a curated plugin set. The Desktop edition uses [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), downloaded automatically during setup.
 

--- a/docs/desktop/en/tmux.md
+++ b/docs/desktop/en/tmux.md
@@ -1,6 +1,6 @@
 # Tmux Guide
 >
-> Terminal multiplexer configuration — v0.41.6
+> Terminal multiplexer configuration — v0.41.7
 
 SetupVibe installs and configures tmux with [TPM](https://github.com/tmux-plugins/tpm) and a curated plugin set. The Desktop edition uses [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), downloaded automatically during setup.
 

--- a/docs/desktop/en/tmux.md
+++ b/docs/desktop/en/tmux.md
@@ -1,6 +1,6 @@
 # Tmux Guide
 >
-> Terminal multiplexer configuration — v0.41.8
+> Terminal multiplexer configuration — v0.41.9
 
 SetupVibe installs and configures tmux with [TPM](https://github.com/tmux-plugins/tpm) and a curated plugin set. The Desktop edition uses [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), downloaded automatically during setup.
 

--- a/docs/desktop/en/tmux.md
+++ b/docs/desktop/en/tmux.md
@@ -1,6 +1,6 @@
 # Tmux Guide
 >
-> Terminal multiplexer configuration — v0.41.9
+> Terminal multiplexer configuration — v0.41.7
 
 SetupVibe installs and configures tmux with [TPM](https://github.com/tmux-plugins/tpm) and a curated plugin set. The Desktop edition uses [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), downloaded automatically during setup.
 

--- a/docs/desktop/es/README.md
+++ b/docs/desktop/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Escritorio
 
-> Configuración de entorno de desarrollo multiplataforma — v0.41.9
+> Configuración de entorno de desarrollo multiplataforma — v0.41.7
 
 Instala y configura un stack de desarrollo completo en un solo comando. Soporta macOS y las principales distribuciones de Linux.
 

--- a/docs/desktop/es/README.md
+++ b/docs/desktop/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Escritorio
 
-> Configuración de entorno de desarrollo multiplataforma — v0.41.8
+> Configuración de entorno de desarrollo multiplataforma — v0.41.9
 
 Instala y configura un stack de desarrollo completo en un solo comando. Soporta macOS y las principales distribuciones de Linux.
 

--- a/docs/desktop/es/README.md
+++ b/docs/desktop/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Escritorio
 
-> Configuración de entorno de desarrollo multiplataforma — v0.41.7
+> Configuración de entorno de desarrollo multiplataforma — v0.41.8
 
 Instala y configura un stack de desarrollo completo en un solo comando. Soporta macOS y las principales distribuciones de Linux.
 
@@ -37,7 +37,7 @@ curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
 bash desktop.sh --install-dotnet=10
 ```
 
-El script muestra una hoja de ruta interactiva y solicita confirmación antes de comenzar. También propone configurar la identidad de Git si aún no está definida.
+El script muestra una hoja de ruta interactiva y solicita confirmación antes de comenzar. Si pasas `--install-dotnet` o ya hay un SDK .NET detectado, el **paso 5** en la hoja de ruta y en el resumen final incluye una nota sobre **.NET**. También propone configurar la identidad de Git si aún no está definida.
 
 ---
 

--- a/docs/desktop/es/README.md
+++ b/docs/desktop/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Escritorio
 
-> Configuración de entorno de desarrollo multiplataforma — v0.41.6
+> Configuración de entorno de desarrollo multiplataforma — v0.41.7
 
 Instala y configura un stack de desarrollo completo en un solo comando. Soporta macOS y las principales distribuciones de Linux.
 
@@ -27,6 +27,14 @@ O localmente:
 
 ```bash
 bash desktop.sh
+```
+
+**.NET SDK** opcional (predeterminado **.NET 10**; majors admitidos `8`, `9`, `10`):
+
+```bash
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
+bash desktop.sh --install-dotnet=10
 ```
 
 El script muestra una hoja de ruta interactiva y solicita confirmación antes de comenzar. También propone configurar la identidad de Git si aún no está definida.

--- a/docs/desktop/es/SPECKIT.md
+++ b/docs/desktop/es/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe instala [Spec-Kit](https://github.com/github/spec-kit) en la edición Desktop (macOS y Linux escritorio) a través de `uv tool install specify-cli`.
 
-> Guía de herramientas — v0.41.9
+> Guía de herramientas — v0.41.7
 
 - **Comando:** `specify`
 - **Paquete:** `specify-cli` (PyPI)

--- a/docs/desktop/es/SPECKIT.md
+++ b/docs/desktop/es/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe instala [Spec-Kit](https://github.com/github/spec-kit) en la edición Desktop (macOS y Linux escritorio) a través de `uv tool install specify-cli`.
 
-> Guía de herramientas — v0.41.6
+> Guía de herramientas — v0.41.7
 
 - **Comando:** `specify`
 - **Paquete:** `specify-cli` (PyPI)

--- a/docs/desktop/es/SPECKIT.md
+++ b/docs/desktop/es/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe instala [Spec-Kit](https://github.com/github/spec-kit) en la edición Desktop (macOS y Linux escritorio) a través de `uv tool install specify-cli`.
 
-> Guía de herramientas — v0.41.8
+> Guía de herramientas — v0.41.9
 
 - **Comando:** `specify`
 - **Paquete:** `specify-cli` (PyPI)

--- a/docs/desktop/es/SPECKIT.md
+++ b/docs/desktop/es/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe instala [Spec-Kit](https://github.com/github/spec-kit) en la edición Desktop (macOS y Linux escritorio) a través de `uv tool install specify-cli`.
 
-> Guía de herramientas — v0.41.7
+> Guía de herramientas — v0.41.8
 
 - **Comando:** `specify`
 - **Paquete:** `specify-cli` (PyPI)

--- a/docs/desktop/es/cronboard.md
+++ b/docs/desktop/es/cronboard.md
@@ -1,6 +1,6 @@
 # Guía de Cronboard
 >
-> Panel de monitoreo Cron TUI — v0.41.9
+> Panel de monitoreo Cron TUI — v0.41.7
 
 SetupVibe instala [Cronboard](https://github.com/antoniorodr/cronboard) para proporcionar una interfaz de usuario de terminal (TUI) para gestionar tareas de cron.
 

--- a/docs/desktop/es/cronboard.md
+++ b/docs/desktop/es/cronboard.md
@@ -1,6 +1,6 @@
 # Guía de Cronboard
 >
-> Panel de monitoreo Cron TUI — v0.41.7
+> Panel de monitoreo Cron TUI — v0.41.8
 
 SetupVibe instala [Cronboard](https://github.com/antoniorodr/cronboard) para proporcionar una interfaz de usuario de terminal (TUI) para gestionar tareas de cron.
 

--- a/docs/desktop/es/cronboard.md
+++ b/docs/desktop/es/cronboard.md
@@ -1,6 +1,6 @@
 # Guía de Cronboard
 >
-> Panel de monitoreo Cron TUI — v0.41.6
+> Panel de monitoreo Cron TUI — v0.41.7
 
 SetupVibe instala [Cronboard](https://github.com/antoniorodr/cronboard) para proporcionar una interfaz de usuario de terminal (TUI) para gestionar tareas de cron.
 

--- a/docs/desktop/es/cronboard.md
+++ b/docs/desktop/es/cronboard.md
@@ -1,6 +1,6 @@
 # Guía de Cronboard
 >
-> Panel de monitoreo Cron TUI — v0.41.8
+> Panel de monitoreo Cron TUI — v0.41.9
 
 SetupVibe instala [Cronboard](https://github.com/antoniorodr/cronboard) para proporcionar una interfaz de usuario de terminal (TUI) para gestionar tareas de cron.
 

--- a/docs/desktop/es/pm2.md
+++ b/docs/desktop/es/pm2.md
@@ -1,6 +1,6 @@
 # Guía de PM2
 >
-> Guía de gestión de procesos — v0.41.7
+> Guía de gestión de procesos — v0.41.8
 
 SetupVibe instala [PM2](https://pm2.keymetrics.io/) globalmente y lo configura para que se inicie automáticamente en la edición Desktop.
 

--- a/docs/desktop/es/pm2.md
+++ b/docs/desktop/es/pm2.md
@@ -1,6 +1,6 @@
 # Guía de PM2
 >
-> Guía de gestión de procesos — v0.41.9
+> Guía de gestión de procesos — v0.41.7
 
 SetupVibe instala [PM2](https://pm2.keymetrics.io/) globalmente y lo configura para que se inicie automáticamente en la edición Desktop.
 

--- a/docs/desktop/es/pm2.md
+++ b/docs/desktop/es/pm2.md
@@ -1,6 +1,6 @@
 # Guía de PM2
 >
-> Guía de gestión de procesos — v0.41.8
+> Guía de gestión de procesos — v0.41.9
 
 SetupVibe instala [PM2](https://pm2.keymetrics.io/) globalmente y lo configura para que se inicie automáticamente en la edición Desktop.
 

--- a/docs/desktop/es/pm2.md
+++ b/docs/desktop/es/pm2.md
@@ -1,6 +1,6 @@
 # Guía de PM2
 >
-> Guía de gestión de procesos — v0.41.6
+> Guía de gestión de procesos — v0.41.7
 
 SetupVibe instala [PM2](https://pm2.keymetrics.io/) globalmente y lo configura para que se inicie automáticamente en la edición Desktop.
 

--- a/docs/desktop/es/tmux.md
+++ b/docs/desktop/es/tmux.md
@@ -1,6 +1,6 @@
 # Guía de Tmux
 >
-> Configuración del multiplexor de terminal — v0.41.8
+> Configuración del multiplexor de terminal — v0.41.9
 
 SetupVibe instala y configura tmux con [TPM](https://github.com/tmux-plugins/tpm) y un conjunto de plugins seleccionados. La edición Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), descargada automáticamente durante la instalación.
 

--- a/docs/desktop/es/tmux.md
+++ b/docs/desktop/es/tmux.md
@@ -1,6 +1,6 @@
 # Guía de Tmux
 >
-> Configuración del multiplexor de terminal — v0.41.7
+> Configuración del multiplexor de terminal — v0.41.8
 
 SetupVibe instala y configura tmux con [TPM](https://github.com/tmux-plugins/tpm) y un conjunto de plugins seleccionados. La edición Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), descargada automáticamente durante la instalación.
 

--- a/docs/desktop/es/tmux.md
+++ b/docs/desktop/es/tmux.md
@@ -1,6 +1,6 @@
 # Guía de Tmux
 >
-> Configuración del multiplexor de terminal — v0.41.9
+> Configuración del multiplexor de terminal — v0.41.7
 
 SetupVibe instala y configura tmux con [TPM](https://github.com/tmux-plugins/tpm) y un conjunto de plugins seleccionados. La edición Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), descargada automáticamente durante la instalación.
 

--- a/docs/desktop/es/tmux.md
+++ b/docs/desktop/es/tmux.md
@@ -1,6 +1,6 @@
 # Guía de Tmux
 >
-> Configuración del multiplexor de terminal — v0.41.6
+> Configuración del multiplexor de terminal — v0.41.7
 
 SetupVibe instala y configura tmux con [TPM](https://github.com/tmux-plugins/tpm) y un conjunto de plugins seleccionados. La edición Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), descargada automáticamente durante la instalación.
 

--- a/docs/desktop/fr/README.md
+++ b/docs/desktop/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Bureau
 
-> Configuration de l'environnement de développement multiplateforme — v0.41.8
+> Configuration de l'environnement de développement multiplateforme — v0.41.9
 
 Installe et configure un stack complet de développeur en une seule commande. Supporte macOS et les principales distributions Linux.
 

--- a/docs/desktop/fr/README.md
+++ b/docs/desktop/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Bureau
 
-> Configuration de l'environnement de développement multiplateforme — v0.41.6
+> Configuration de l'environnement de développement multiplateforme — v0.41.7
 
 Installe et configure un stack complet de développeur en une seule commande. Supporte macOS et les principales distributions Linux.
 
@@ -27,6 +27,14 @@ Ou localement :
 
 ```bash
 bash desktop.sh
+```
+
+**.NET SDK** facultatif (par défaut **.NET 10** ; versions majeures prises en charge `8`, `9`, `10`) :
+
+```bash
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
+bash desktop.sh --install-dotnet=10
 ```
 
 Le script affiche une feuille de route interactive et demande confirmation avant de commencer. Il propose également de configurer l'identité Git si elle n'est pas déjà définie.

--- a/docs/desktop/fr/README.md
+++ b/docs/desktop/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Bureau
 
-> Configuration de l'environnement de développement multiplateforme — v0.41.7
+> Configuration de l'environnement de développement multiplateforme — v0.41.8
 
 Installe et configure un stack complet de développeur en une seule commande. Supporte macOS et les principales distributions Linux.
 
@@ -37,7 +37,7 @@ curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
 bash desktop.sh --install-dotnet=10
 ```
 
-Le script affiche une feuille de route interactive et demande confirmation avant de commencer. Il propose également de configurer l'identité Git si elle n'est pas déjà définie.
+Le script affiche une feuille de route interactive et demande confirmation avant de commencer. Si vous passez `--install-dotnet` ou qu'un SDK .NET est déjà détecté, l'**étape 5** dans la feuille de route et dans le récapitulatif final inclut une mention de **.NET**. Il propose également de configurer l'identité Git si elle n'est pas déjà définie.
 
 ---
 

--- a/docs/desktop/fr/README.md
+++ b/docs/desktop/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Bureau
 
-> Configuration de l'environnement de développement multiplateforme — v0.41.9
+> Configuration de l'environnement de développement multiplateforme — v0.41.7
 
 Installe et configure un stack complet de développeur en une seule commande. Supporte macOS et les principales distributions Linux.
 

--- a/docs/desktop/fr/SPECKIT.md
+++ b/docs/desktop/fr/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe installe [Spec-Kit](https://github.com/github/spec-kit) sur l'édition Desktop (macOS et Linux bureau) via `uv tool install specify-cli`.
 
-> Guide des outils — v0.41.7
+> Guide des outils — v0.41.8
 
 - **Commande :** `specify`
 - **Paquet :** `specify-cli` (PyPI)

--- a/docs/desktop/fr/SPECKIT.md
+++ b/docs/desktop/fr/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe installe [Spec-Kit](https://github.com/github/spec-kit) sur l'édition Desktop (macOS et Linux bureau) via `uv tool install specify-cli`.
 
-> Guide des outils — v0.41.6
+> Guide des outils — v0.41.7
 
 - **Commande :** `specify`
 - **Paquet :** `specify-cli` (PyPI)

--- a/docs/desktop/fr/SPECKIT.md
+++ b/docs/desktop/fr/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe installe [Spec-Kit](https://github.com/github/spec-kit) sur l'édition Desktop (macOS et Linux bureau) via `uv tool install specify-cli`.
 
-> Guide des outils — v0.41.9
+> Guide des outils — v0.41.7
 
 - **Commande :** `specify`
 - **Paquet :** `specify-cli` (PyPI)

--- a/docs/desktop/fr/SPECKIT.md
+++ b/docs/desktop/fr/SPECKIT.md
@@ -2,7 +2,7 @@
 
 SetupVibe installe [Spec-Kit](https://github.com/github/spec-kit) sur l'édition Desktop (macOS et Linux bureau) via `uv tool install specify-cli`.
 
-> Guide des outils — v0.41.8
+> Guide des outils — v0.41.9
 
 - **Commande :** `specify`
 - **Paquet :** `specify-cli` (PyPI)

--- a/docs/desktop/fr/cronboard.md
+++ b/docs/desktop/fr/cronboard.md
@@ -1,6 +1,6 @@
 # Guide Cronboard
 >
-> Tableau de bord de surveillance Cron TUI — v0.41.9
+> Tableau de bord de surveillance Cron TUI — v0.41.7
 
 SetupVibe installe [Cronboard](https://github.com/antoniorodr/cronboard) pour fournir une interface utilisateur de terminal (TUI) pour la gestion des tâches cron.
 

--- a/docs/desktop/fr/cronboard.md
+++ b/docs/desktop/fr/cronboard.md
@@ -1,6 +1,6 @@
 # Guide Cronboard
 >
-> Tableau de bord de surveillance Cron TUI — v0.41.7
+> Tableau de bord de surveillance Cron TUI — v0.41.8
 
 SetupVibe installe [Cronboard](https://github.com/antoniorodr/cronboard) pour fournir une interface utilisateur de terminal (TUI) pour la gestion des tâches cron.
 

--- a/docs/desktop/fr/cronboard.md
+++ b/docs/desktop/fr/cronboard.md
@@ -1,6 +1,6 @@
 # Guide Cronboard
 >
-> Tableau de bord de surveillance Cron TUI — v0.41.6
+> Tableau de bord de surveillance Cron TUI — v0.41.7
 
 SetupVibe installe [Cronboard](https://github.com/antoniorodr/cronboard) pour fournir une interface utilisateur de terminal (TUI) pour la gestion des tâches cron.
 

--- a/docs/desktop/fr/cronboard.md
+++ b/docs/desktop/fr/cronboard.md
@@ -1,6 +1,6 @@
 # Guide Cronboard
 >
-> Tableau de bord de surveillance Cron TUI — v0.41.8
+> Tableau de bord de surveillance Cron TUI — v0.41.9
 
 SetupVibe installe [Cronboard](https://github.com/antoniorodr/cronboard) pour fournir une interface utilisateur de terminal (TUI) pour la gestion des tâches cron.
 

--- a/docs/desktop/fr/pm2.md
+++ b/docs/desktop/fr/pm2.md
@@ -1,6 +1,6 @@
 # Guide PM2
 >
-> Guide de gestion de processus — v0.41.7
+> Guide de gestion de processus — v0.41.8
 
 SetupVibe installe [PM2](https://pm2.keymetrics.io/) globalement et le configure pour un démarrage automatique sur l'édition Desktop.
 

--- a/docs/desktop/fr/pm2.md
+++ b/docs/desktop/fr/pm2.md
@@ -1,6 +1,6 @@
 # Guide PM2
 >
-> Guide de gestion de processus — v0.41.9
+> Guide de gestion de processus — v0.41.7
 
 SetupVibe installe [PM2](https://pm2.keymetrics.io/) globalement et le configure pour un démarrage automatique sur l'édition Desktop.
 

--- a/docs/desktop/fr/pm2.md
+++ b/docs/desktop/fr/pm2.md
@@ -1,6 +1,6 @@
 # Guide PM2
 >
-> Guide de gestion de processus — v0.41.6
+> Guide de gestion de processus — v0.41.7
 
 SetupVibe installe [PM2](https://pm2.keymetrics.io/) globalement et le configure pour un démarrage automatique sur l'édition Desktop.
 

--- a/docs/desktop/fr/pm2.md
+++ b/docs/desktop/fr/pm2.md
@@ -1,6 +1,6 @@
 # Guide PM2
 >
-> Guide de gestion de processus — v0.41.8
+> Guide de gestion de processus — v0.41.9
 
 SetupVibe installe [PM2](https://pm2.keymetrics.io/) globalement et le configure pour un démarrage automatique sur l'édition Desktop.
 

--- a/docs/desktop/fr/tmux.md
+++ b/docs/desktop/fr/tmux.md
@@ -1,6 +1,6 @@
 # Guide Tmux
 >
-> Configuration do multiplexeur de terminal — v0.41.9
+> Configuration do multiplexeur de terminal — v0.41.7
 
 SetupVibe installe et configure tmux avec [TPM](https://github.com/tmux-plugins/tpm) et un ensemble de plugins sélectionnés. L'édition Desktop utilise [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), téléchargée automatiquement lors de l'installation.
 

--- a/docs/desktop/fr/tmux.md
+++ b/docs/desktop/fr/tmux.md
@@ -1,6 +1,6 @@
 # Guide Tmux
 >
-> Configuration do multiplexeur de terminal — v0.41.6
+> Configuration do multiplexeur de terminal — v0.41.7
 
 SetupVibe installe et configure tmux avec [TPM](https://github.com/tmux-plugins/tpm) et un ensemble de plugins sélectionnés. L'édition Desktop utilise [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), téléchargée automatiquement lors de l'installation.
 

--- a/docs/desktop/fr/tmux.md
+++ b/docs/desktop/fr/tmux.md
@@ -1,6 +1,6 @@
 # Guide Tmux
 >
-> Configuration do multiplexeur de terminal — v0.41.8
+> Configuration do multiplexeur de terminal — v0.41.9
 
 SetupVibe installe et configure tmux avec [TPM](https://github.com/tmux-plugins/tpm) et un ensemble de plugins sélectionnés. L'édition Desktop utilise [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), téléchargée automatiquement lors de l'installation.
 

--- a/docs/desktop/fr/tmux.md
+++ b/docs/desktop/fr/tmux.md
@@ -1,6 +1,6 @@
 # Guide Tmux
 >
-> Configuration do multiplexeur de terminal — v0.41.7
+> Configuration do multiplexeur de terminal — v0.41.8
 
 SetupVibe installe et configure tmux avec [TPM](https://github.com/tmux-plugins/tpm) et un ensemble de plugins sélectionnés. L'édition Desktop utilise [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), téléchargée automatiquement lors de l'installation.
 

--- a/docs/desktop/pt-br/README.md
+++ b/docs/desktop/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Desktop
 
-> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.7
+> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.8
 
 Instala e configura um stack de desenvolvedor completo em um comando. Suporta macOS e as principais distribuições Linux.
 
@@ -37,7 +37,7 @@ curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
 bash desktop.sh --install-dotnet=10
 ```
 
-O script exibe um roteiro interativo e solicita confirmação antes de iniciar. Também solicita a configuração da identidade do Git, caso ainda não esteja definida.
+O script exibe um roteiro interativo e solicita confirmação antes de iniciar. Se você usar `--install-dotnet` ou um SDK .NET já for detectado, a **etapa 5** no roteiro e no resumo final inclui uma menção ao **.NET**. Também solicita a configuração da identidade do Git, caso ainda não esteja definida.
 
 ---
 

--- a/docs/desktop/pt-br/README.md
+++ b/docs/desktop/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Desktop
 
-> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.8
+> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.9
 
 Instala e configura um stack de desenvolvedor completo em um comando. Suporta macOS e as principais distribuições Linux.
 

--- a/docs/desktop/pt-br/README.md
+++ b/docs/desktop/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Desktop
 
-> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.9
+> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.7
 
 Instala e configura um stack de desenvolvedor completo em um comando. Suporta macOS e as principais distribuições Linux.
 

--- a/docs/desktop/pt-br/README.md
+++ b/docs/desktop/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Desktop
 
-> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.6
+> Configuração de ambiente de desenvolvimento multiplataforma — v0.41.7
 
 Instala e configura um stack de desenvolvedor completo em um comando. Suporta macOS e as principais distribuições Linux.
 
@@ -27,6 +27,14 @@ Ou localmente:
 
 ```bash
 bash desktop.sh
+```
+
+**.NET SDK** opcional (padrão **.NET 10**; majors suportados `8`, `9`, `10`):
+
+```bash
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet=8
+bash desktop.sh --install-dotnet=10
 ```
 
 O script exibe um roteiro interativo e solicita confirmação antes de iniciar. Também solicita a configuração da identidade do Git, caso ainda não esteja definida.

--- a/docs/desktop/pt-br/SPECKIT.md
+++ b/docs/desktop/pt-br/SPECKIT.md
@@ -2,7 +2,7 @@
 
 O SetupVibe instala o [Spec-Kit](https://github.com/github/spec-kit) na edição Desktop (macOS e Linux desktop) via `uv tool install specify-cli`.
 
-> Guia de ferramentas — v0.41.9
+> Guia de ferramentas — v0.41.7
 
 - **Comando:** `specify`
 - **Pacote:** `specify-cli` (PyPI)

--- a/docs/desktop/pt-br/SPECKIT.md
+++ b/docs/desktop/pt-br/SPECKIT.md
@@ -2,7 +2,7 @@
 
 O SetupVibe instala o [Spec-Kit](https://github.com/github/spec-kit) na edição Desktop (macOS e Linux desktop) via `uv tool install specify-cli`.
 
-> Guia de ferramentas — v0.41.6
+> Guia de ferramentas — v0.41.7
 
 - **Comando:** `specify`
 - **Pacote:** `specify-cli` (PyPI)

--- a/docs/desktop/pt-br/SPECKIT.md
+++ b/docs/desktop/pt-br/SPECKIT.md
@@ -2,7 +2,7 @@
 
 O SetupVibe instala o [Spec-Kit](https://github.com/github/spec-kit) na edição Desktop (macOS e Linux desktop) via `uv tool install specify-cli`.
 
-> Guia de ferramentas — v0.41.8
+> Guia de ferramentas — v0.41.9
 
 - **Comando:** `specify`
 - **Pacote:** `specify-cli` (PyPI)

--- a/docs/desktop/pt-br/SPECKIT.md
+++ b/docs/desktop/pt-br/SPECKIT.md
@@ -2,7 +2,7 @@
 
 O SetupVibe instala o [Spec-Kit](https://github.com/github/spec-kit) na edição Desktop (macOS e Linux desktop) via `uv tool install specify-cli`.
 
-> Guia de ferramentas — v0.41.7
+> Guia de ferramentas — v0.41.8
 
 - **Comando:** `specify`
 - **Pacote:** `specify-cli` (PyPI)

--- a/docs/desktop/pt-br/cronboard.md
+++ b/docs/desktop/pt-br/cronboard.md
@@ -1,6 +1,6 @@
 # Guia do Cronboard
 >
-> Dashboard de monitoramento Cron TUI — v0.41.9
+> Dashboard de monitoramento Cron TUI — v0.41.7
 
 O SetupVibe instala o [Cronboard](https://github.com/antoniorodr/cronboard) para fornecer uma interface visual (TUI) para gerenciamento de tarefas cron.
 

--- a/docs/desktop/pt-br/cronboard.md
+++ b/docs/desktop/pt-br/cronboard.md
@@ -1,6 +1,6 @@
 # Guia do Cronboard
 >
-> Dashboard de monitoramento Cron TUI — v0.41.7
+> Dashboard de monitoramento Cron TUI — v0.41.8
 
 O SetupVibe instala o [Cronboard](https://github.com/antoniorodr/cronboard) para fornecer uma interface visual (TUI) para gerenciamento de tarefas cron.
 

--- a/docs/desktop/pt-br/cronboard.md
+++ b/docs/desktop/pt-br/cronboard.md
@@ -1,6 +1,6 @@
 # Guia do Cronboard
 >
-> Dashboard de monitoramento Cron TUI — v0.41.8
+> Dashboard de monitoramento Cron TUI — v0.41.9
 
 O SetupVibe instala o [Cronboard](https://github.com/antoniorodr/cronboard) para fornecer uma interface visual (TUI) para gerenciamento de tarefas cron.
 

--- a/docs/desktop/pt-br/cronboard.md
+++ b/docs/desktop/pt-br/cronboard.md
@@ -1,6 +1,6 @@
 # Guia do Cronboard
 >
-> Dashboard de monitoramento Cron TUI — v0.41.6
+> Dashboard de monitoramento Cron TUI — v0.41.7
 
 O SetupVibe instala o [Cronboard](https://github.com/antoniorodr/cronboard) para fornecer uma interface visual (TUI) para gerenciamento de tarefas cron.
 

--- a/docs/desktop/pt-br/pm2.md
+++ b/docs/desktop/pt-br/pm2.md
@@ -1,6 +1,6 @@
 # Guia do PM2
 >
-> Guia de gerenciamento de processos — v0.41.6
+> Guia de gerenciamento de processos — v0.41.7
 
 O SetupVibe instala o [PM2](https://pm2.keymetrics.io/) globalmente e o configura para inicialização automática na edição Desktop.
 

--- a/docs/desktop/pt-br/pm2.md
+++ b/docs/desktop/pt-br/pm2.md
@@ -1,6 +1,6 @@
 # Guia do PM2
 >
-> Guia de gerenciamento de processos — v0.41.9
+> Guia de gerenciamento de processos — v0.41.7
 
 O SetupVibe instala o [PM2](https://pm2.keymetrics.io/) globalmente e o configura para inicialização automática na edição Desktop.
 

--- a/docs/desktop/pt-br/pm2.md
+++ b/docs/desktop/pt-br/pm2.md
@@ -1,6 +1,6 @@
 # Guia do PM2
 >
-> Guia de gerenciamento de processos — v0.41.7
+> Guia de gerenciamento de processos — v0.41.8
 
 O SetupVibe instala o [PM2](https://pm2.keymetrics.io/) globalmente e o configura para inicialização automática na edição Desktop.
 

--- a/docs/desktop/pt-br/pm2.md
+++ b/docs/desktop/pt-br/pm2.md
@@ -1,6 +1,6 @@
 # Guia do PM2
 >
-> Guia de gerenciamento de processos — v0.41.8
+> Guia de gerenciamento de processos — v0.41.9
 
 O SetupVibe instala o [PM2](https://pm2.keymetrics.io/) globalmente e o configura para inicialização automática na edição Desktop.
 

--- a/docs/desktop/pt-br/tmux.md
+++ b/docs/desktop/pt-br/tmux.md
@@ -1,6 +1,6 @@
 # Guia do Tmux
 >
-> Configuração do multiplexador de terminal — v0.41.6
+> Configuração do multiplexador de terminal — v0.41.7
 
 O SetupVibe instala e configura o tmux com o [TPM](https://github.com/tmux-plugins/tpm) e um conjunto selecionado de plugins. A Edição Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), baixada automaticamente durante a instalação.
 

--- a/docs/desktop/pt-br/tmux.md
+++ b/docs/desktop/pt-br/tmux.md
@@ -1,6 +1,6 @@
 # Guia do Tmux
 >
-> Configuração do multiplexador de terminal — v0.41.7
+> Configuração do multiplexador de terminal — v0.41.8
 
 O SetupVibe instala e configura o tmux com o [TPM](https://github.com/tmux-plugins/tpm) e um conjunto selecionado de plugins. A Edição Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), baixada automaticamente durante a instalação.
 

--- a/docs/desktop/pt-br/tmux.md
+++ b/docs/desktop/pt-br/tmux.md
@@ -1,6 +1,6 @@
 # Guia do Tmux
 >
-> Configuração do multiplexador de terminal — v0.41.9
+> Configuração do multiplexador de terminal — v0.41.7
 
 O SetupVibe instala e configura o tmux com o [TPM](https://github.com/tmux-plugins/tpm) e um conjunto selecionado de plugins. A Edição Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), baixada automaticamente durante a instalação.
 

--- a/docs/desktop/pt-br/tmux.md
+++ b/docs/desktop/pt-br/tmux.md
@@ -1,6 +1,6 @@
 # Guia do Tmux
 >
-> Configuração do multiplexador de terminal — v0.41.8
+> Configuração do multiplexador de terminal — v0.41.9
 
 O SetupVibe instala e configura o tmux com o [TPM](https://github.com/tmux-plugins/tpm) e um conjunto selecionado de plugins. A Edição Desktop usa [`conf/tmux-desktop.conf`](../../../conf/tmux-desktop.conf), baixada automaticamente durante a instalação.
 

--- a/docs/en/ALIAS.md
+++ b/docs/en/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Shell environment aliases — v0.41.6
+> Shell environment aliases — v0.41.7
 
 This is the exhaustive list of all aliases configured by SetupVibe on all platforms.
 

--- a/docs/en/ALIAS.md
+++ b/docs/en/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Shell environment aliases — v0.41.7
+> Shell environment aliases — v0.41.8
 
 This is the exhaustive list of all aliases configured by SetupVibe on all platforms.
 

--- a/docs/en/ALIAS.md
+++ b/docs/en/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Shell environment aliases — v0.41.9
+> Shell environment aliases — v0.41.7
 
 This is the exhaustive list of all aliases configured by SetupVibe on all platforms.
 

--- a/docs/en/ALIAS.md
+++ b/docs/en/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Shell environment aliases — v0.41.8
+> Shell environment aliases — v0.41.9
 
 This is the exhaustive list of all aliases configured by SetupVibe on all platforms.
 

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -57,7 +57,7 @@ All `.md` files must follow these rules strictly:
 
 ## 🔢 Versioning Process
 
-When updating the version (e.g., from `0.41.9` to `0.42.0`), you **must** update the version string in all of the following locations:
+When updating the version (e.g., from `0.41.7` to `0.42.0`), you **must** update the version string in all of the following locations:
 
 - `desktop.sh` (the `VERSION` variable)
 - `server.sh` (the `VERSION` variable)

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -57,7 +57,7 @@ All `.md` files must follow these rules strictly:
 
 ## 🔢 Versioning Process
 
-When updating the version (e.g., from `0.41.6` to `0.42.0`), you **must** update the version string in all of the following locations:
+When updating the version (e.g., from `0.41.7` to `0.42.0`), you **must** update the version string in all of the following locations:
 
 - `desktop.sh` (the `VERSION` variable)
 - `server.sh` (the `VERSION` variable)

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -57,7 +57,7 @@ All `.md` files must follow these rules strictly:
 
 ## 🔢 Versioning Process
 
-When updating the version (e.g., from `0.41.7` to `0.42.0`), you **must** update the version string in all of the following locations:
+When updating the version (e.g., from `0.41.8` to `0.42.0`), you **must** update the version string in all of the following locations:
 
 - `desktop.sh` (the `VERSION` variable)
 - `server.sh` (the `VERSION` variable)

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -57,7 +57,7 @@ All `.md` files must follow these rules strictly:
 
 ## 🔢 Versioning Process
 
-When updating the version (e.g., from `0.41.8` to `0.42.0`), you **must** update the version string in all of the following locations:
+When updating the version (e.g., from `0.41.9` to `0.42.0`), you **must** update the version string in all of the following locations:
 
 - `desktop.sh` (the `VERSION` variable)
 - `server.sh` (the `VERSION` variable)

--- a/docs/es/ALIAS.md
+++ b/docs/es/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases de SetupVibe
 
-> Aliases del entorno de shell — v0.41.9
+> Aliases del entorno de shell — v0.41.7
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/es/ALIAS.md
+++ b/docs/es/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases de SetupVibe
 
-> Aliases del entorno de shell — v0.41.7
+> Aliases del entorno de shell — v0.41.8
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/es/ALIAS.md
+++ b/docs/es/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases de SetupVibe
 
-> Aliases del entorno de shell — v0.41.6
+> Aliases del entorno de shell — v0.41.7
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/es/ALIAS.md
+++ b/docs/es/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases de SetupVibe
 
-> Aliases del entorno de shell — v0.41.8
+> Aliases del entorno de shell — v0.41.9
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos los archivos `.md` deben seguir estas reglas estrictamente:
 
 ## 🔢 Proceso de Versionado
 
-Al actualizar la versión (ej: de `0.41.9` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
+Al actualizar la versión (ej: de `0.41.7` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos los archivos `.md` deben seguir estas reglas estrictamente:
 
 ## 🔢 Proceso de Versionado
 
-Al actualizar la versión (ej: de `0.41.7` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
+Al actualizar la versión (ej: de `0.41.8` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos los archivos `.md` deben seguir estas reglas estrictamente:
 
 ## 🔢 Proceso de Versionado
 
-Al actualizar la versión (ej: de `0.41.6` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
+Al actualizar la versión (ej: de `0.41.7` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos los archivos `.md` deben seguir estas reglas estrictamente:
 
 ## 🔢 Proceso de Versionado
 
-Al actualizar la versión (ej: de `0.41.8` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
+Al actualizar la versión (ej: de `0.41.9` a `0.42.0`), **debes** actualizar la cadena de versión en todas las siguientes ubicaciones:
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/fr/ALIAS.md
+++ b/docs/fr/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases SetupVibe
 
-> Alias de l'environnement shell — v0.41.8
+> Alias de l'environnement shell — v0.41.9
 
 Voici la liste exhaustive de todos os aliases configurados por SetupVibe sur toutes les plateformes.
 

--- a/docs/fr/ALIAS.md
+++ b/docs/fr/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases SetupVibe
 
-> Alias de l'environnement shell — v0.41.7
+> Alias de l'environnement shell — v0.41.8
 
 Voici la liste exhaustive de todos os aliases configurados por SetupVibe sur toutes les plateformes.
 

--- a/docs/fr/ALIAS.md
+++ b/docs/fr/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases SetupVibe
 
-> Alias de l'environnement shell — v0.41.6
+> Alias de l'environnement shell — v0.41.7
 
 Voici la liste exhaustive de todos os aliases configurados por SetupVibe sur toutes les plateformes.
 

--- a/docs/fr/ALIAS.md
+++ b/docs/fr/ALIAS.md
@@ -1,6 +1,6 @@
 # Aliases SetupVibe
 
-> Alias de l'environnement shell — v0.41.9
+> Alias de l'environnement shell — v0.41.7
 
 Voici la liste exhaustive de todos os aliases configurados por SetupVibe sur toutes les plateformes.
 

--- a/docs/fr/CONTRIBUTING.md
+++ b/docs/fr/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Tous les fichiers `.md` doivent suivre strictement ces règles :
 
 ## 🔢 Processus de Versionnage
 
-Lors de la mise à jour de la version (ex : de `0.41.9` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
+Lors de la mise à jour de la version (ex : de `0.41.7` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/fr/CONTRIBUTING.md
+++ b/docs/fr/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Tous les fichiers `.md` doivent suivre strictement ces règles :
 
 ## 🔢 Processus de Versionnage
 
-Lors de la mise à jour de la version (ex : de `0.41.6` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
+Lors de la mise à jour de la version (ex : de `0.41.7` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/fr/CONTRIBUTING.md
+++ b/docs/fr/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Tous les fichiers `.md` doivent suivre strictement ces règles :
 
 ## 🔢 Processus de Versionnage
 
-Lors de la mise à jour de la version (ex : de `0.41.7` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
+Lors de la mise à jour de la version (ex : de `0.41.8` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/fr/CONTRIBUTING.md
+++ b/docs/fr/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Tous les fichiers `.md` doivent suivre strictement ces règles :
 
 ## 🔢 Processus de Versionnage
 
-Lors de la mise à jour de la version (ex : de `0.41.8` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
+Lors de la mise à jour de la version (ex : de `0.41.9` à `0.42.0`), vous **devez** mettre à jour la chaîne de version dans tous les emplacements suivants :
 
 - `desktop.sh` (variable `VERSION`)
 - `server.sh` (variable `VERSION`)

--- a/docs/pt-br/ALIAS.md
+++ b/docs/pt-br/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Aliases do ambiente shell — v0.41.8
+> Aliases do ambiente shell — v0.41.9
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/pt-br/ALIAS.md
+++ b/docs/pt-br/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Aliases do ambiente shell — v0.41.6
+> Aliases do ambiente shell — v0.41.7
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/pt-br/ALIAS.md
+++ b/docs/pt-br/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Aliases do ambiente shell — v0.41.9
+> Aliases do ambiente shell — v0.41.7
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/pt-br/ALIAS.md
+++ b/docs/pt-br/ALIAS.md
@@ -1,6 +1,6 @@
 # SetupVibe Aliases
 
-> Aliases do ambiente shell — v0.41.7
+> Aliases do ambiente shell — v0.41.8
 
 Esta é a lista exaustiva de todos os aliases configurados pelo SetupVibe em todas as plataformas.
 

--- a/docs/pt-br/CONTRIBUTING.md
+++ b/docs/pt-br/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos os arquivos `.md` devem seguir estas regras rigorosamente:
 
 ## 🔢 Processo de Versionamento
 
-Ao atualizar a versão (ex: de `0.41.8` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
+Ao atualizar a versão (ex: de `0.41.9` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
 
 - `desktop.sh` (variável `VERSION`)
 - `server.sh` (variável `VERSION`)

--- a/docs/pt-br/CONTRIBUTING.md
+++ b/docs/pt-br/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos os arquivos `.md` devem seguir estas regras rigorosamente:
 
 ## 🔢 Processo de Versionamento
 
-Ao atualizar a versão (ex: de `0.41.9` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
+Ao atualizar a versão (ex: de `0.41.7` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
 
 - `desktop.sh` (variável `VERSION`)
 - `server.sh` (variável `VERSION`)

--- a/docs/pt-br/CONTRIBUTING.md
+++ b/docs/pt-br/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos os arquivos `.md` devem seguir estas regras rigorosamente:
 
 ## 🔢 Processo de Versionamento
 
-Ao atualizar a versão (ex: de `0.41.6` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
+Ao atualizar a versão (ex: de `0.41.7` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
 
 - `desktop.sh` (variável `VERSION`)
 - `server.sh` (variável `VERSION`)

--- a/docs/pt-br/CONTRIBUTING.md
+++ b/docs/pt-br/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Todos os arquivos `.md` devem seguir estas regras rigorosamente:
 
 ## 🔢 Processo de Versionamento
 
-Ao atualizar a versão (ex: de `0.41.7` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
+Ao atualizar a versão (ex: de `0.41.8` para `0.42.0`), você **deve** atualizar a string de versão em todos os seguintes locais:
 
 - `desktop.sh` (variável `VERSION`)
 - `server.sh` (variável `VERSION`)

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,8 +1,8 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.6
+> Linux server setup — v0.41.7
 
-Lean Linux-only setup for production servers. No Homebrew, no language ecosystems. Installs Docker, Ansible, GitHub CLI, networking tools, Tailscale, SSH, shell, tmux, and AI CLI tools via NodeSource Node.js. Optionally configures the machine as a Docker Swarm Manager node via the `--manager` flag.
+Lean Linux-only setup for production servers. No Homebrew. Installs Docker, Ansible, GitHub CLI, networking tools, Tailscale, SSH, shell, tmux, and AI CLI tools via NodeSource Node.js. Optionally installs the .NET SDK via `--install-dotnet` (default .NET 10). Optionally configures the machine as a Docker Swarm Manager node via the `--manager` flag.
 
 ## Documentation
 

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.7
+> Linux server setup — v0.41.8
 
 Lean Linux-only setup for production servers. No Homebrew. Installs Docker, Ansible, GitHub CLI, networking tools, Tailscale, SSH, shell, tmux, and AI CLI tools via NodeSource Node.js. Optionally installs the .NET SDK via `--install-dotnet` (default .NET 10). Optionally configures the machine as a Docker Swarm Manager node via the `--manager` flag.
 

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.8
+> Linux server setup — v0.41.9
 
 Lean Linux-only setup for production servers. No Homebrew. Installs Docker, Ansible, GitHub CLI, networking tools, Tailscale, SSH, shell, tmux, and AI CLI tools via NodeSource Node.js. Optionally installs the .NET SDK via `--install-dotnet` (default .NET 10). Optionally configures the machine as a Docker Swarm Manager node via the `--manager` flag.
 

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.9
+> Linux server setup — v0.41.7
 
 Lean Linux-only setup for production servers. No Homebrew. Installs Docker, Ansible, GitHub CLI, networking tools, Tailscale, SSH, shell, tmux, and AI CLI tools via NodeSource Node.js. Optionally installs the .NET SDK via `--install-dotnet` (default .NET 10). Optionally configures the machine as a Docker Swarm Manager node via the `--manager` flag.
 

--- a/docs/server/en/README.md
+++ b/docs/server/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.6
+> Linux server setup — v0.41.7
 
 A lean, focused setup script for Linux servers. No Homebrew, no language ecosystems, no desktop tools. Installs only what a production server needs: Docker, Ansible, networking, shell, tmux, and AI CLI tools.
 
@@ -36,6 +36,15 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager
 
 ```bash
 bash server.sh --manager
+```
+
+Optional **.NET SDK** (default **.NET 10**; supported majors `8`, `9`, `10`). Compatible with `--manager`:
+
+```bash
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet=8
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
+bash server.sh --install-dotnet=10
 ```
 
 The script waits for any running APT lock to clear (useful on fresh cloud VMs where `unattended-upgrades` runs at boot), shows an interactive roadmap, then asks for confirmation. It also prompts to configure Git identity if not already set. At the end of installation, if `--manager` was not passed, the script will interactively ask whether to configure the machine as a Docker Swarm Manager.

--- a/docs/server/en/README.md
+++ b/docs/server/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.9
+> Linux server setup — v0.41.7
 
 A lean, focused setup script for Linux servers. No Homebrew, no language ecosystems, no desktop tools. Installs only what a production server needs: Docker, Ansible, networking, shell, tmux, and AI CLI tools.
 

--- a/docs/server/en/README.md
+++ b/docs/server/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.7
+> Linux server setup — v0.41.8
 
 A lean, focused setup script for Linux servers. No Homebrew, no language ecosystems, no desktop tools. Installs only what a production server needs: Docker, Ansible, networking, shell, tmux, and AI CLI tools.
 
@@ -47,7 +47,7 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 bash server.sh --install-dotnet=10
 ```
 
-The script waits for any running APT lock to clear (useful on fresh cloud VMs where `unattended-upgrades` runs at boot), shows an interactive roadmap, then asks for confirmation. It also prompts to configure Git identity if not already set. At the end of installation, if `--manager` was not passed, the script will interactively ask whether to configure the machine as a Docker Swarm Manager.
+The script waits for any running APT lock to clear (useful on fresh cloud VMs where `unattended-upgrades` runs at boot), shows an interactive roadmap, then asks for confirmation. If you pass `--install-dotnet` or a .NET SDK is already detected, the **AI CLI Tools** step in the roadmap and in the final summary includes a **.NET** note. It also prompts to configure Git identity if not already set. At the end of installation, if `--manager` was not passed, the script will interactively ask whether to configure the machine as a Docker Swarm Manager.
 
 ---
 

--- a/docs/server/en/README.md
+++ b/docs/server/en/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Server Edition
 
-> Linux server setup — v0.41.8
+> Linux server setup — v0.41.9
 
 A lean, focused setup script for Linux servers. No Homebrew, no language ecosystems, no desktop tools. Installs only what a production server needs: Docker, Ansible, networking, shell, tmux, and AI CLI tools.
 

--- a/docs/server/es/README.md
+++ b/docs/server/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Servidor
 
-> Configuración de servidor Linux — v0.41.7
+> Configuración de servidor Linux — v0.41.8
 
 Un script de configuración ligero y enfocado para servidores Linux. Sin Homebrew, sin ecosistemas de lenguajes, sin herramientas de escritorio. Instala solo lo que un servidor de producción necesita: Docker, Ansible, redes, shell, tmux y herramientas AI CLI.
 
@@ -47,7 +47,7 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 bash server.sh --install-dotnet=10
 ```
 
-El script espera a que se libere cualquier bloqueo de APT (útil en máquinas virtuales recién creadas donde `unattended-upgrades` se ejecuta al arrancar), muestra una hoja de ruta interactiva y luego solicita confirmación. También propone configurar la identidad de Git si aún no está definida. Al final de la instalación, si no se pasó `--manager`, el script preguntará interactivamente si se desea configurar la máquina como Manager de Docker Swarm.
+El script espera a que se libere cualquier bloqueo de APT (útil en máquinas virtuales recién creadas donde `unattended-upgrades` se ejecuta al arrancar), muestra una hoja de ruta interactiva y luego solicita confirmación. Si pasas `--install-dotnet` o ya hay un SDK .NET detectado, el paso **Herramientas AI CLI** en la hoja de ruta y en el resumen final incluye una nota sobre **.NET**. También propone configurar la identidad de Git si aún no está definida. Al final de la instalación, si no se pasó `--manager`, el script preguntará interactivamente si se desea configurar la máquina como Manager de Docker Swarm.
 
 ---
 

--- a/docs/server/es/README.md
+++ b/docs/server/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Servidor
 
-> Configuración de servidor Linux — v0.41.8
+> Configuración de servidor Linux — v0.41.9
 
 Un script de configuración ligero y enfocado para servidores Linux. Sin Homebrew, sin ecosistemas de lenguajes, sin herramientas de escritorio. Instala solo lo que un servidor de producción necesita: Docker, Ansible, redes, shell, tmux y herramientas AI CLI.
 

--- a/docs/server/es/README.md
+++ b/docs/server/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Servidor
 
-> Configuración de servidor Linux — v0.41.6
+> Configuración de servidor Linux — v0.41.7
 
 Un script de configuración ligero y enfocado para servidores Linux. Sin Homebrew, sin ecosistemas de lenguajes, sin herramientas de escritorio. Instala solo lo que un servidor de producción necesita: Docker, Ansible, redes, shell, tmux y herramientas AI CLI.
 
@@ -36,6 +36,15 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager
 
 ```bash
 bash server.sh --manager
+```
+
+**.NET SDK** opcional (predeterminado **.NET 10**; compatible con `--manager`):
+
+```bash
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet=8
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
+bash server.sh --install-dotnet=10
 ```
 
 El script espera a que se libere cualquier bloqueo de APT (útil en máquinas virtuales recién creadas donde `unattended-upgrades` se ejecuta al arrancar), muestra una hoja de ruta interactiva y luego solicita confirmación. También propone configurar la identidad de Git si aún no está definida. Al final de la instalación, si no se pasó `--manager`, el script preguntará interactivamente si se desea configurar la máquina como Manager de Docker Swarm.

--- a/docs/server/es/README.md
+++ b/docs/server/es/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edición Servidor
 
-> Configuración de servidor Linux — v0.41.9
+> Configuración de servidor Linux — v0.41.7
 
 Un script de configuración ligero y enfocado para servidores Linux. Sin Homebrew, sin ecosistemas de lenguajes, sin herramientas de escritorio. Instala solo lo que un servidor de producción necesita: Docker, Ansible, redes, shell, tmux y herramientas AI CLI.
 

--- a/docs/server/fr/README.md
+++ b/docs/server/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Serveur
 
-> Configuration de serveur Linux — v0.41.8
+> Configuration de serveur Linux — v0.41.9
 
 Un script de configuration léger et ciblé pour les serveurs Linux. Pas de Homebrew, pas d'écosystèmes de langages, pas d'outils de bureau. Installe uniquement ce dont un serveur de production a besoin : Docker, Ansible, réseau, shell, tmux et outils AI CLI.
 

--- a/docs/server/fr/README.md
+++ b/docs/server/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Serveur
 
-> Configuration de serveur Linux — v0.41.9
+> Configuration de serveur Linux — v0.41.7
 
 Un script de configuration léger et ciblé pour les serveurs Linux. Pas de Homebrew, pas d'écosystèmes de langages, pas d'outils de bureau. Installe uniquement ce dont un serveur de production a besoin : Docker, Ansible, réseau, shell, tmux et outils AI CLI.
 

--- a/docs/server/fr/README.md
+++ b/docs/server/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Serveur
 
-> Configuration de serveur Linux — v0.41.7
+> Configuration de serveur Linux — v0.41.8
 
 Un script de configuration léger et ciblé pour les serveurs Linux. Pas de Homebrew, pas d'écosystèmes de langages, pas d'outils de bureau. Installe uniquement ce dont un serveur de production a besoin : Docker, Ansible, réseau, shell, tmux et outils AI CLI.
 
@@ -47,7 +47,7 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 bash server.sh --install-dotnet=10
 ```
 
-Le script attend que tout verrou APT en cours soit libéré (utile sur les VMs cloud neuves où `unattended-upgrades` s'exécute au boot), affiche une feuille de route interactive, puis demande confirmation. Il propose également de configurer l'identité Git si elle n'est pas déjà définie. À la fin de l'installation, si `--manager` n'a pas été passé, le script demandera interactivement si la machine doit être configurée comme Manager Docker Swarm.
+Le script attend que tout verrou APT en cours soit libéré (utile sur les VMs cloud neuves où `unattended-upgrades` s'exécute au boot), affiche une feuille de route interactive, puis demande confirmation. Si vous passez `--install-dotnet` ou qu'un SDK .NET est déjà détecté, l'étape **Outils AI CLI** dans la feuille de route et dans le récapitulatif final inclut une mention de **.NET**. Il propose également de configurer l'identité Git si elle n'est pas déjà définie. À la fin de l'installation, si `--manager` n'a pas été passé, le script demandera interactivement si la machine doit être configurée comme Manager Docker Swarm.
 
 ---
 

--- a/docs/server/fr/README.md
+++ b/docs/server/fr/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Édition Serveur
 
-> Configuration de serveur Linux — v0.41.6
+> Configuration de serveur Linux — v0.41.7
 
 Un script de configuration léger et ciblé pour les serveurs Linux. Pas de Homebrew, pas d'écosystèmes de langages, pas d'outils de bureau. Installe uniquement ce dont un serveur de production a besoin : Docker, Ansible, réseau, shell, tmux et outils AI CLI.
 
@@ -36,6 +36,15 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager
 
 ```bash
 bash server.sh --manager
+```
+
+**.NET SDK** facultatif (par défaut **.NET 10** ; compatible avec `--manager`) :
+
+```bash
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet=8
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
+bash server.sh --install-dotnet=10
 ```
 
 Le script attend que tout verrou APT en cours soit libéré (utile sur les VMs cloud neuves où `unattended-upgrades` s'exécute au boot), affiche une feuille de route interactive, puis demande confirmation. Il propose également de configurer l'identité Git si elle n'est pas déjà définie. À la fin de l'installation, si `--manager` n'a pas été passé, le script demandera interactivement si la machine doit être configurée comme Manager Docker Swarm.

--- a/docs/server/pt-br/README.md
+++ b/docs/server/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Servidor
 
-> Configuração de servidor Linux — v0.41.9
+> Configuração de servidor Linux — v0.41.7
 
 Um script de configuração enxuto e focado para servidores Linux. Sem Homebrew, sem ecossistemas de linguagens, sem ferramentas de desktop. Instala apenas o que um servidor de produção precisa: Docker, Ansible, rede, shell, tmux e ferramentas AI CLI.
 

--- a/docs/server/pt-br/README.md
+++ b/docs/server/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Servidor
 
-> Configuração de servidor Linux — v0.41.8
+> Configuração de servidor Linux — v0.41.9
 
 Um script de configuração enxuto e focado para servidores Linux. Sem Homebrew, sem ecossistemas de linguagens, sem ferramentas de desktop. Instala apenas o que um servidor de produção precisa: Docker, Ansible, rede, shell, tmux e ferramentas AI CLI.
 

--- a/docs/server/pt-br/README.md
+++ b/docs/server/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Servidor
 
-> Configuração de servidor Linux — v0.41.7
+> Configuração de servidor Linux — v0.41.8
 
 Um script de configuração enxuto e focado para servidores Linux. Sem Homebrew, sem ecossistemas de linguagens, sem ferramentas de desktop. Instala apenas o que um servidor de produção precisa: Docker, Ansible, rede, shell, tmux e ferramentas AI CLI.
 
@@ -47,7 +47,7 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
 bash server.sh --install-dotnet=10
 ```
 
-O script aguarda a liberação de qualquer bloqueio do APT (útil em VMs de nuvem recém-criadas onde o `unattended-upgrades` é executado no boot), exibe um roteiro interativo e solicita confirmação. Também solicita a configuração da identidade do Git, caso ainda não esteja definida. Ao final da instalação, se `--manager` não foi informado, o script perguntará interativamente se a máquina deve ser configurada como Manager do Docker Swarm.
+O script aguarda a liberação de qualquer bloqueio do APT (útil em VMs de nuvem recém-criadas onde o `unattended-upgrades` é executado no boot), exibe um roteiro interativo e solicita confirmação. Se você usar `--install-dotnet` ou um SDK .NET já for detectado, a etapa **Ferramentas AI CLI** no roteiro e no resumo final inclui uma menção ao **.NET**. Também solicita a configuração da identidade do Git, caso ainda não esteja definida. Ao final da instalação, se `--manager` não foi informado, o script perguntará interativamente se a máquina deve ser configurada como Manager do Docker Swarm.
 
 ---
 

--- a/docs/server/pt-br/README.md
+++ b/docs/server/pt-br/README.md
@@ -1,6 +1,6 @@
 # SetupVibe — Edição Servidor
 
-> Configuração de servidor Linux — v0.41.6
+> Configuração de servidor Linux — v0.41.7
 
 Um script de configuração enxuto e focado para servidores Linux. Sem Homebrew, sem ecossistemas de linguagens, sem ferramentas de desktop. Instala apenas o que um servidor de produção precisa: Docker, Ansible, rede, shell, tmux e ferramentas AI CLI.
 
@@ -36,6 +36,15 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager
 
 ```bash
 bash server.sh --manager
+```
+
+**.NET SDK** opcional (padrão **.NET 10**; majors suportados `8`, `9`, `10`). Compatível com `--manager`:
+
+```bash
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet
+curl -sSL server.setupvibe.dev | bash -s -- --install-dotnet=8
+curl -sSL server.setupvibe.dev | bash -s -- --manager --install-dotnet
+bash server.sh --install-dotnet=10
 ```
 
 O script aguarda a liberação de qualquer bloqueio do APT (útil em VMs de nuvem recém-criadas onde o `unattended-upgrades` é executado no boot), exibe um roteiro interativo e solicita confirmação. Também solicita a configuração da identidade do Git, caso ainda não esteja definida. Ao final da instalação, se `--manager` não foi informado, o script perguntará interativamente se a máquina deve ser configurada como Manager do Docker Swarm.

--- a/server.sh
+++ b/server.sh
@@ -26,19 +26,41 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.6"
+VERSION="0.41.7"
 INSTALL_URL="https://server.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---
 SWARM_MANAGER=false
+INSTALL_DOTNET=false
+DOTNET_MAJOR=""
 for arg in "$@"; do
     case "$arg" in
         --manager) SWARM_MANAGER=true ;;
+        --install-dotnet)
+            INSTALL_DOTNET=true
+            DOTNET_MAJOR="10"
+            ;;
+        --install-dotnet=*)
+            INSTALL_DOTNET=true
+            DOTNET_MAJOR="${arg#*=}"
+            ;;
     esac
 done
+if $INSTALL_DOTNET; then
+    case "$DOTNET_MAJOR" in
+        8|9|10) ;;
+        *)
+            echo -e "${RED}Error: --install-dotnet requires major version 8, 9, or 10 (e.g. --install-dotnet=9).${NC}"
+            exit 1
+            ;;
+    esac
+fi
 
 echo -e "${CYAN}SetupVibe Server Edition v${VERSION}${NC}"
 [[ "$SWARM_MANAGER" == "true" ]] && echo -e "${YELLOW}  → Docker Swarm Manager mode enabled${NC}"
+if $INSTALL_DOTNET; then
+    echo -e "${YELLOW}  → .NET SDK ${DOTNET_MAJOR}.x install requested${NC}"
+fi
 echo ""
 
 # --- ENVIRONMENT ---
@@ -114,7 +136,7 @@ sys_do mkdir -p -m 755 /etc/apt/keyrings
 
 # Remove third-party repos managed by this script to ensure we start from a clean state
 # This prevents the signature verification error if the keys were deleted but the lists remained
-sys_do grep -rl 'docker\|nodesource\|charm\.sh\|cli\.github\|ansible\|codeiumdata\|windsurf\|antigravity\|pkg\.dev' \
+sys_do grep -rl 'docker\|nodesource\|charm\.sh\|cli\.github\|ansible\|codeiumdata\|windsurf\|antigravity\|pkg\.dev\|packages\.microsoft' \
     /etc/apt/sources.list.d/ 2>/dev/null | xargs -I {} sys_do rm -f "{}" 2>/dev/null || true
 
 # Clean APT cache if we are root
@@ -261,6 +283,74 @@ install_key() {
     fi
     echo -e "${RED}✘ Failed to install key from $url${NC}"
     return 1
+}
+
+_install_dotnet_via_install_script() {
+    local inst_dir="$REAL_HOME/.dotnet"
+    echo -e "${YELLOW}Installing .NET SDK via dotnet-install.sh (channel ${DOTNET_MAJOR}.0) → $inst_dir${NC}"
+    user_do mkdir -p "$inst_dir"
+    local script
+    script=$(mktemp /tmp/dotnet-install.XXXXXX.sh)
+    if ! curl -fsSL "https://dot.net/v1/dotnet-install.sh" -o "$script"; then
+        echo -e "${RED}✘ Failed to download dotnet-install.sh${NC}"
+        rm -f "$script"
+        return 1
+    fi
+    chmod +x "$script"
+    if user_do bash "$script" --channel "${DOTNET_MAJOR}.0" --install-dir "$inst_dir"; then
+        rm -f "$script"
+        if user_do test -x "$inst_dir/dotnet"; then
+            echo -e "${GREEN}✔ .NET SDK installed to $inst_dir${NC}"
+            return 0
+        fi
+    fi
+    rm -f "$script"
+    echo -e "${RED}✘ .NET SDK installation failed.${NC}"
+    return 1
+}
+
+install_dotnet_sdk() {
+    echo ""
+    echo -e "${BLUE}========================================================${NC}"
+    echo -e "${BOLD}▶ .NET SDK (${DOTNET_MAJOR}.x)${NC}"
+    echo -e "${BLUE}========================================================${NC}"
+    local sdk_pkg="dotnet-sdk-${DOTNET_MAJOR}.0"
+
+    if $IS_UBUNTU || $IS_DEBIAN; then
+        local msdeb=""
+        local ubver=""
+        local dver=""
+        if $IS_UBUNTU; then
+            ubver=$(lsb_release -rs 2>/dev/null)
+            [[ -n "$ubver" ]] && msdeb="https://packages.microsoft.com/config/ubuntu/${ubver}/packages-microsoft-prod.deb"
+        else
+            dver=$(grep -E '^VERSION_ID=' /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"')
+            [[ -n "$dver" ]] && msdeb="https://packages.microsoft.com/config/debian/${dver}/packages-microsoft-prod.deb"
+        fi
+
+        if [[ -n "$msdeb" ]]; then
+            local tmpdeb
+            tmpdeb=$(mktemp /tmp/msprodXXXXXX.deb)
+            echo -e "${YELLOW}Adding Microsoft package repository...${NC}"
+            if curl -fsSL "$msdeb" -o "$tmpdeb" && sys_do dpkg -i "$tmpdeb"; then
+                rm -f "$tmpdeb"
+                sys_do apt-get install -f -y -qq 2>/dev/null || true
+                sys_do apt-get update -qq
+                if sys_do apt-get install -y "$sdk_pkg"; then
+                    echo -e "${GREEN}✔ .NET SDK installed via APT (${sdk_pkg}).${NC}"
+                    command -v dotnet >/dev/null 2>&1 && user_do dotnet --version
+                    return 0
+                fi
+            else
+                rm -f "$tmpdeb"
+            fi
+            echo -e "${YELLOW}⚠ APT install failed or package unavailable — trying dotnet-install.sh...${NC}"
+        fi
+    else
+        echo -e "${YELLOW}⚠ Non-Debian/Ubuntu Linux — using dotnet-install.sh...${NC}"
+    fi
+
+    _install_dotnet_via_install_script
 }
 
 header() {
@@ -636,6 +726,10 @@ step_6() {
 
 
 step_7() {
+    if $INSTALL_DOTNET; then
+        install_dotnet_sdk || echo -e "${YELLOW}⚠ .NET SDK step finished with warnings.${NC}"
+    fi
+
     echo "Installing Node.js 24 via NodeSource..."
     install_key "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" "/etc/apt/keyrings/nodesource.gpg"
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | sys_do tee /etc/apt/sources.list.d/nodesource.list

--- a/server.sh
+++ b/server.sh
@@ -26,7 +26,7 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.7"
+VERSION="0.41.8"
 INSTALL_URL="https://server.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---
@@ -840,9 +840,33 @@ step_swarm() {
 }
 
 
+# Adjust roadmap/summary labels when .NET install is requested or already present
+update_steps_dotnet_labels() {
+    local base="AI CLI Tools"
+    if $INSTALL_DOTNET; then
+        STEPS[7]="${base} (incl. .NET SDK ${DOTNET_MAJOR}.x)"
+        return
+    fi
+    local dver=""
+    if [[ -x "$REAL_HOME/.dotnet/dotnet" ]]; then
+        dver=$(user_do env HOME="$REAL_HOME" PATH="$REAL_HOME/.dotnet:${PATH}" "$REAL_HOME/.dotnet/dotnet" --version 2>/dev/null | head -1 | tr -d '\r' || true)
+    fi
+    if [[ -z "$dver" ]] && user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; command -v dotnet' &>/dev/null; then
+        dver=$(user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; dotnet --version 2>/dev/null' | head -1 | tr -d '\r' || true)
+    fi
+    if [[ -z "$dver" ]] && command -v dotnet &>/dev/null; then
+        dver=$(dotnet --version 2>/dev/null | head -1 | tr -d '\r' || true)
+    fi
+    if [[ -n "$dver" ]]; then
+        STEPS[7]="${base} [.NET present: ${dver}]"
+    fi
+}
+
+
 # --- MAIN EXECUTION ---
 
 
+update_steps_dotnet_labels
 show_roadmap_and_wait
 configure_git_interactive
 

--- a/server.sh
+++ b/server.sh
@@ -26,7 +26,7 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.9"
+VERSION="0.41.7"
 INSTALL_URL="https://server.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---

--- a/server.sh
+++ b/server.sh
@@ -26,7 +26,7 @@ NC='\033[0m' # No Color
 
 
 # --- VERSION ---
-VERSION="0.41.8"
+VERSION="0.41.9"
 INSTALL_URL="https://server.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---
@@ -848,11 +848,14 @@ update_steps_dotnet_labels() {
         return
     fi
     local dver=""
-    if [[ -x "$REAL_HOME/.dotnet/dotnet" ]]; then
-        dver=$(user_do env HOME="$REAL_HOME" PATH="$REAL_HOME/.dotnet:${PATH}" "$REAL_HOME/.dotnet/dotnet" --version 2>/dev/null | head -1 | tr -d '\r' || true)
-    fi
-    if [[ -z "$dver" ]] && user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; command -v dotnet' &>/dev/null; then
-        dver=$(user_do bash -lc 'export PATH="$HOME/.dotnet:/usr/local/bin:/usr/bin:$PATH"; dotnet --version 2>/dev/null' | head -1 | tr -d '\r' || true)
+    local cand
+    for cand in "$REAL_HOME/.dotnet/dotnet" "/usr/bin/dotnet" "/usr/share/dotnet/dotnet"; do
+        [[ -e "$cand" ]] || continue
+        dver=$(user_do env HOME="$REAL_HOME" PATH="$(dirname "$cand"):/usr/local/bin:/usr/bin:${PATH}" "$cand" --version 2>/dev/null | head -1 | tr -d '\r' || true)
+        [[ -n "$dver" ]] && break
+    done
+    if [[ -z "$dver" ]]; then
+        dver=$(user_do bash -c 'export PATH="$HOME/.dotnet:/snap/bin:/usr/local/bin:/usr/bin:$PATH"; command -v dotnet >/dev/null 2>&1 && dotnet --version' 2>/dev/null | head -1 | tr -d '\r' || true)
     fi
     if [[ -z "$dver" ]] && command -v dotnet &>/dev/null; then
         dver=$(dotnet --version 2>/dev/null | head -1 | tr -d '\r' || true)


### PR DESCRIPTION
## Summary

This PR adds an optional **.NET SDK** installation path to **SetupVibe Desktop** and **Server**, controlled by CLI flags, with Linux (APT + fallback script) and macOS (`dotnet-install.sh`) support. It also fixes **line endings** for shell scripts, improves **roadmap / final summary** labels when .NET is requested or already present, and bumps documentation and version metadata.

## What’s included

### .NET installation

- **`--install-dotnet`** — installs the **.NET SDK** with default channel aligned to **.NET 10** (LTS).
- **`--install-dotnet=8|9|10`** — installs the chosen major SDK series.
- **Server:** flag is **compatible** with existing **`--manager`** (any order).
- **Linux:** Microsoft **APT** repo via `packages-microsoft-prod` when possible; **fallback** to official **`dotnet-install.sh`** to `~/.dotnet`.
- **macOS (Desktop):** SDK via **`dotnet-install.sh`** under `~/.dotnet`.
- **Execution point:** Desktop — end of **step 5** (Languages); Server — start of **step 7** (before Node / AI CLI tools).

### Shell environment

- **`conf/zshrc-*.zsh`:** if `~/.dotnet` exists, sets **`DOTNET_ROOT`** and extends **`PATH`** (`~/.dotnet`, `~/.dotnet/tools`).

### Roadmap & installation summary

- **`update_steps_dotnet_labels()`** runs **before** the interactive roadmap so **step titles** reflect .NET when:
  - **`--install-dotnet`** is passed, or  
  - an existing **`dotnet`** is detected (paths such as `~/.dotnet/dotnet`, `/usr/bin/dotnet`, `/usr/share/dotnet/dotnet`, plus **`bash -c`** with **`PATH`** including **`snap/bin`** — avoids fragile **`bash -l`** / missed APT installs).

### Repository hygiene

- **`.gitattributes`:** `*.sh text eol=lf` so Bash on Linux/macOS does not hit **`$'\r': command not found`**.
- Shell scripts normalized to **LF** where needed.

### Versioning & docs

- Version bumped (current: **v0.41.9** in scripts and synced docs).
- **`CHANGELOG.md`** entries for the feature, roadmap labels, and .NET detection fix.
- **`README`**, **`docs/**`**, **`AGENTS.md` / `CLAUDE.md` / `GEMINI.md`** updated for flags, behaviour, and version.

## How to test

**Desktop (local clone):**

```bash
bash desktop.sh --install-dotnet
bash desktop.sh --install-dotnet=8
```

**Server:**

```bash
bash server.sh --install-dotnet
bash server.sh --manager --install-dotnet
```

**Piped install:**

```bash
curl -sSL desktop.setupvibe.dev | bash -s -- --install-dotnet
```

After install: `dotnet --version` and confirm roadmap / summary show the .NET note when applicable.

**WSL / clean machine:** reset distro or use a fresh VM to re-run the full flow.