### PR TITLE
fix(desktop): prevent pecl prompts from consuming the script via stdin

### DIFF
--- a/desktop.sh
+++ b/desktop.sh
@@ -603,10 +603,16 @@ step_3() {
         brew_cmd link php@8.4 --force --overwrite
         
         # Install common extensions via PECL
+        # NOTE: pecl prompts interactively (e.g. redis asks about igbinary/lzf/
+        # zstd/msgpack/lz4). When this script is run via `curl ... | bash`, stdin
+        # IS the script, so pecl would read the following script lines as prompt
+        # answers, producing a broken ./configure call and silently consuming the
+        # rest of the script. Feeding `yes ''` answers every prompt with its
+        # default and isolates stdin from the script body.
         echo "Installing PHP Extensions..."
-        user_do pecl install redis 2>/dev/null || true
-        user_do pecl install xdebug 2>/dev/null || true
-        printf "\n" | user_do pecl install imagick 2>/dev/null || true
+        yes '' | user_do pecl install redis 2>/dev/null || true
+        yes '' | user_do pecl install xdebug 2>/dev/null || true
+        yes '' | user_do pecl install imagick 2>/dev/null || true
         
         echo "Installing Composer..."
         if [ ! -f "$REAL_HOME/.local/bin/composer" ] && ! command -v composer &>/dev/null; then


### PR DESCRIPTION
## Problema

Ao rodar o instalador da forma documentada no README:

```bash
curl -sSL desktop.setupvibe.dev | bash
```

o script **para no meio do passo `[3/14] PHP 8.4 Ecosystem`** com o erro:

```
checking build system type... Invalid configuration '3': machine '3-unknown' not recognized
configure: error: /bin/sh .../config.sub 3 failed
ERROR: `.../configure ... --enable-redis-igbinary=run_section 3 step_4 --enable-redis-lzf=run_section 4 step_5 ...' failed
```

## Causa raiz

Quando o script é executado via `curl ... | bash`, o **stdin do processo é o próprio script**.

`pecl install redis` faz perguntas **interativas** (igbinary, lzf, zstd, msgpack, lz4, use system liblz4) e lê as respostas do stdin. Como o stdin é o script, o `pecl` consome as **próximas linhas do desktop.sh** (`run_section 3 step_4`, `run_section 4 step_5`, …) como se fossem respostas — gerando um `./configure` malformado (`machine '3-unknown'…`).

Pior: como essas linhas foram consumidas do stdin, o `bash` nunca as executa, então o script **encerra silenciosamente no meio**.

## Correção

Encanar `yes ''` em cada `pecl install` para:
1. responder todos os prompts com o valor **default**; e
2. **isolar o stdin** do corpo do script.

## Teste

Verificado de ponta a ponta no **macOS (Apple Silicon, PHP 8.4.22)**:

- Reproduzido o bug com stdin poluído → `machine '3-unknown' not recognized`.
- Com o fix → `Build process completed successfully`, extensão `redis` presente em `php -m`.
- Instalador roda os **14 passos** até `SetupVibe Desktop Completed Successfully! 🚀` (antes morria no passo 3).

Closes #22
