### PR TITLE
fix(desktop): evaluate MAKE_OPTS so macOS Ruby build gets a valid -jN

### DIFF
--- a/desktop.sh
+++ b/desktop.sh
@@ -673,8 +673,14 @@ step_4() {
         echo "Checking Ruby 3.3.0..."
         if ! user_do rbenv versions --bare | grep -q "^3.3.0$"; then
             echo "Compiling Ruby 3.3.0 (this may take a few minutes)..."
-            # Optimization: Skip documentation and use parallel compilation
-            user_do bash -c "export RUBY_CONFIGURE_OPTS='--disable-install-doc'; export MAKE_OPTS='-j\$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)'; rbenv install 3.3.0"
+            # Optimization: Skip documentation and use parallel compilation.
+            # Use single quotes for the outer `bash -c` and double quotes for the
+            # values so $(...) is evaluated by the inner shell. With the previous
+            # double-quoted outer + single-quoted, escaped \$(...), MAKE_OPTS was
+            # stored literally as "-j$(nproc ...)" and ruby-build ran a broken
+            # `make "-j$(nproc" ...`, failing the build (and cascading the Rails
+            # install onto system Ruby). Mirrors the Linux path below.
+            user_do bash -c 'export RUBY_CONFIGURE_OPTS="--disable-install-doc"; export MAKE_OPTS="-j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"; rbenv install 3.3.0'
             user_do rbenv global 3.3.0
         fi
         


### PR DESCRIPTION
## Problema

No macOS, o passo `[4/14] Ruby Ecosystem (Rails)` falha ao compilar o Ruby 3.3.0:

```
-> make "-j$(nproc" 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)

BUILD FAILED (macOS 26.5.1 on arm64 using ruby-build 20260616)
rbenv: version `3.3.0' not installed
Installing Rails...
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.6.0 directory.
```

## Causa raiz

A linha do macOS monta `MAKE_OPTS` com `bash -c` entre **aspas duplas**, contendo um valor entre **aspas simples** com `\$(...)`:

```bash
user_do bash -c "export ... export MAKE_OPTS='-j\$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)'; rbenv install 3.3.0"
```

A substituição de comando **nunca é avaliada** — `MAKE_OPTS` fica com a string literal `-j$(nproc ...)`. O ruby-build então executa um `make "-j$(nproc" ...` inválido, o build falha e o Ruby 3.3.0 não é instalado.

Como consequência, o `gem install bundler rails` seguinte cai no **Ruby do sistema** (`/Library/Ruby/Gems/2.6.0`) e falha com `Gem::FilePermissionError`.

> O caminho Linux (logo abaixo no mesmo `step_4`) já faz o correto, usando aspas simples no `bash -c` externo e aspas duplas no valor.

## Correção

Alinhar o macOS ao padrão do Linux: aspas simples no `bash -c` externo + aspas duplas nos valores, para que `$(...)` seja avaliado pelo shell interno. **O valor continua dinâmico** (`-j` = nº de núcleos), apenas passa a ser de fato avaliado.

## Teste

Verificado no **macOS (Apple Silicon, macOS 26.5.1, ruby-build 20260616)**:

- **Antes**: `MAKE_OPTS=[-j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)]` → `BUILD FAILED`.
- **Depois**: `$(...)` avaliado corretamente (`-j4`/`-j8`/`-j10`/… conforme a máquina, com fallback `-j2`); o build roda `-> make -jN` e instala o Ruby 3.3.0 com sucesso (`rbenv versions` lista `3.3.0`), eliminando o erro de permissão no `gem install`.
