### PR TITLE
feat: update desktop toolchain and harden installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ Both `desktop.sh` and `server.sh` follow a numbered-step pattern (functions pref
 
 1. Base system & build tools
 2. Homebrew
-3. PHP 8.4 (Composer, Laravel)
-4. Ruby (rbenv, Rails)
-5. Go, Rust, Python (uv)
+3. PHP 8.5 (Composer, Laravel)
+4. Ruby 3.4.10 (rbenv, Rails)
+5. Go 1.26.5, Rust, Python (uv; Python 3.14 on macOS)
 6. JavaScript (Node, Bun, PNPM)
 7. DevOps (Docker, Ansible, GitHub CLI)
 8. Modern Unix tools via Homebrew

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ All notable changes to **SetupVibe** are documented in this file.
 
 - Updated AI context synchronization to cover only `AGENTS.md` and `CLAUDE.md`.
 - Split agent skills into platform-specific `.codex/skills` and `.claude/skills` folders.
+- Updated the Desktop Edition to PHP 8.5, Ruby 3.4.10, Go 1.26.5, Python 3.14 on macOS, and Nerd Fonts 3.4.0.
+- Replaced the deprecated `@githubnext/github-copilot-cli` package with `@github/copilot` in the Desktop and Server editions.
+- Replaced the beta n8n client package `@n8n/cli` with the full `n8n` workflow automation package.
+- Restricted Linux Desktop root SSH access to public-key authentication and moved SetupVibe settings to an `sshd_config.d` drop-in.
+- Limited macOS cleanup to Homebrew and SetupVibe-owned temporary files instead of deleting user caches and Trash contents.
+
+### Fixed
+
+- Fixed macOS Ruby compilation by evaluating `MAKE_OPTS` inside the target user shell.
+- Added SHA-256 verification and version-aware replacement for the Go Linux archive.
+- Hardened APT key downloads and repository cleanup so failed pipelines cannot create empty keyrings or delete user-managed source files.
+- Restored native Debian 13 (`trixie`) repositories for PHP and Docker instead of falling back to Debian 12.
+- Fixed downloads performed as root so artifacts placed in the real user's home retain the correct ownership.
+- Removed the temporary unrestricted `NOPASSWD:ALL` sudoers rule previously used by the Linux Homebrew installation.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,9 @@ Both `desktop.sh` and `server.sh` follow a numbered-step pattern (functions pref
 
 1. Base system & build tools
 2. Homebrew
-3. PHP 8.4 (Composer, Laravel)
-4. Ruby (rbenv, Rails)
-5. Go, Rust, Python (uv)
+3. PHP 8.5 (Composer, Laravel)
+4. Ruby 3.4.10 (rbenv, Rails)
+5. Go 1.26.5, Rust, Python (uv; Python 3.14 on macOS)
 6. JavaScript (Node, Bun, PNPM)
 7. DevOps (Docker, Ansible, GitHub CLI)
 8. Modern Unix tools via Homebrew

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Installs and configures a complete development stack in one command, supporting 
 - **Auto-Update:** Automatically upgrades existing Homebrew packages during setup.
 - **Modern Shell:** ZSH + Oh My Zsh + Starship with a curated set of plugins and aliases.
 - **Optimized Tmux:** Pre-configured with TPM, intuitive keybindings, and window/pane numbering starting at 1.
+- **Current Runtimes:** PHP 8.5, Ruby 3.4.10, Go 1.26.5, Python 3.14 on macOS, and Node.js 24 LTS.
 - **AI-Ready:** Includes the latest AI CLI tools for developers.
 
 ## Documentation

--- a/desktop.sh
+++ b/desktop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 
 # ==============================================================================
 # SETUPVIBE.DEV - DESKTOP DEVELOPER EDITION (V2.3 - Cross Platform)
@@ -26,7 +28,11 @@ NC='\033[0m' # No Color
 
 # --- VERSION ---
 VERSION="0.41.6"
-INSTALL_URL="https://desktop.setupvibe.dev"
+PHP_VERSION="8.5"
+RUBY_VERSION="3.4.10"
+PYTHON_VERSION="3.14"
+GO_VERSION="1.26.5"
+NERD_FONTS_VERSION="3.4.0"
 
 echo -e "${CYAN}SetupVibe Desktop v${VERSION}${NC}"
 echo ""
@@ -51,6 +57,15 @@ sys_do() {
         sudo "$@"
     else
         "$@"
+    fi
+}
+
+# Run Homebrew as the real user and isolate stdin from curl-piped installs.
+brew_cmd() {
+    if [[ "$(id -u)" -eq 0 && -n "$REAL_USER" && "$REAL_USER" != "root" ]]; then
+        ( cd "$REAL_HOME" && runuser -u "$REAL_USER" -- env HOME="$REAL_HOME" "$BREW_PREFIX/bin/brew" "$@" < /dev/null )
+    else
+        "$BREW_PREFIX/bin/brew" "$@" < /dev/null
     fi
 }
 
@@ -111,10 +126,17 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     echo -e "${YELLOW}Ensuring base tools (gpg, curl, ca-certificates)...${NC}"
     export DEBIAN_FRONTEND=noninteractive
     
-    # If we have errors in APT, we try to fix them by removing potentially broken lists managed by this script
-    # This prevents the error you saw: signature verification failed because keys were deleted
-    sys_do grep -rl 'docker\|nodesource\|charm\.sh\|cli\.github\|sury\|ondrej\|ansible\|codeiumdata\|windsurf\|antigravity\|pkg\.dev' \
-        /etc/apt/sources.list.d/ 2>/dev/null | xargs -I {} sys_do rm -f "{}" 2>/dev/null || true
+    # Remove only repository files owned by SetupVibe. Content-based deletion can
+    # remove repositories managed by the user or another package manager.
+    for source_file in \
+        /etc/apt/sources.list.d/charm.list \
+        /etc/apt/sources.list.d/docker.list \
+        /etc/apt/sources.list.d/github-cli.list \
+        /etc/apt/sources.list.d/nodesource.list \
+        /etc/apt/sources.list.d/php.list; do
+        sys_do rm -f -- "$source_file"
+    done
+    unset source_file
 
     sys_do apt-get update -y -qq
     sys_do apt-get install -y -q gnupg gnupg2 curl ca-certificates lsb-release software-properties-common apt-transport-https
@@ -142,8 +164,8 @@ fi
 STEPS=(
     "Base System & Build Tools"
     "Homebrew (Package Manager)"
-    "PHP 8.4 Ecosystem (Laravel)"
-    "Ruby Ecosystem (Rails)"
+    "PHP ${PHP_VERSION} Ecosystem (Laravel)"
+    "Ruby ${RUBY_VERSION} Ecosystem (Rails)"
     "Languages (Go, Rust, Python + uv)"
     "JavaScript (Node, Bun, PNPM)"
     "DevOps (Docker, Ansible, GH)"
@@ -219,6 +241,7 @@ if [[ "$REAL_USER" == "root" && -d "/home/linuxbrew/.linuxbrew" ]]; then
 fi
 REAL_HOME=$(getent passwd "$REAL_USER" 2>/dev/null | cut -d: -f6)
 [[ -z "$REAL_HOME" ]] && REAL_HOME="$HOME"
+REAL_GROUP=$(id -gn "$REAL_USER" 2>/dev/null || echo "$REAL_USER")
 
 
 # Detect Distro (Linux only)
@@ -295,34 +318,42 @@ fi
 install_key() {
     local url=$1
     local dest=$2
+    local source_tmp
+    local key_tmp
+
     echo -e "${YELLOW}Installing key:${NC} $url ➜ $dest"
     sys_do mkdir -p -m 755 /etc/apt/keyrings
-    # Try dearmor if GPG is available
+
+    source_tmp=$(mktemp) || return 1
+    key_tmp=$(mktemp) || {
+        rm -f -- "$source_tmp"
+        return 1
+    }
+
+    if ! curl -fsSL --proto '=https' --tlsv1.2 --max-time 30 "$url" -o "$source_tmp"; then
+        echo -e "${RED}✘ Failed to download key from $url${NC}"
+        rm -f -- "$source_tmp" "$key_tmp"
+        return 1
+    fi
+
+    # Prefer a binary keyring when GPG is available.
     if [[ -n "$GPG_CMD" ]] && command -v "$GPG_CMD" >/dev/null 2>&1; then
-        if curl -fsSL "$url" | "$GPG_CMD" --dearmor --yes | sys_do tee "$dest" > /dev/null; then
-            sys_do chmod a+r "$dest"
+        if "$GPG_CMD" --dearmor --yes --output "$key_tmp" "$source_tmp" 2>/dev/null \
+            && sys_do install -m 0644 "$key_tmp" "$dest"; then
+            rm -f -- "$source_tmp" "$key_tmp"
             return 0
         fi
     fi
-    # Fallback: download as-is (modern APT handles armored keys)
-    if curl -fsSL "$url" | sys_do tee "$dest" > /dev/null; then
-        sys_do chmod a+r "$dest"
+
+    # Modern APT also accepts an armored keyring.
+    if sys_do install -m 0644 "$source_tmp" "$dest"; then
+        rm -f -- "$source_tmp" "$key_tmp"
         return 0
     fi
+
+    rm -f -- "$source_tmp" "$key_tmp"
     echo -e "${RED}✘ Failed to install key from $url${NC}"
     return 1
-}
-
-# Helper function to run brew as regular user (not root)
-brew_cmd() {
-    if [[ "$(id -u)" -eq 0 && -n "$REAL_USER" && "$REAL_USER" != "root" ]]; then
-        # Use runuser; cd to user home first (runuser inherits CWD and /root is not readable by others)
-        # Redirect stdin from /dev/null to prevent brew from consuming the script when run via curl|bash
-        ( cd "$REAL_HOME" && runuser -u "$REAL_USER" -- env HOME="$REAL_HOME" "$BREW_PREFIX/bin/brew" "$@" < /dev/null )
-    else
-        # Redirect stdin from /dev/null to prevent brew from consuming the script when run via curl|bash
-        "$BREW_PREFIX/bin/brew" "$@" < /dev/null
-    fi
 }
 
 header() {
@@ -378,13 +409,13 @@ configure_git_interactive() {
 
         while [[ -z "$GIT_NAME" ]]; do
             echo -ne "Enter your Full Name: "
-            read GIT_NAME < /dev/tty
+            read -r GIT_NAME < /dev/tty
         done
 
 
         while [[ -z "$GIT_EMAIL" ]]; do
             echo -ne "Enter your Email: "
-            read GIT_EMAIL < /dev/tty
+            read -r GIT_EMAIL < /dev/tty
         done
 
         user_do git config --global user.name "$GIT_NAME"
@@ -422,7 +453,7 @@ git_ensure() {
         echo "Cloning: $repo..."
         user_do git clone "$repo" "$dest" --quiet
     fi
-    sys_do chown -R $REAL_USER:$(id -gn $REAL_USER) "$dest" 2>/dev/null || true
+    sys_do chown -R "$REAL_USER:$REAL_GROUP" "$dest" 2>/dev/null || true
 }
 
 safe_download() {
@@ -462,7 +493,17 @@ safe_download() {
         user_do mkdir -p "$dest_dir"
     fi
 
-    user_do mv "$tmp" "$dest"
+    if [[ "$(id -u)" -eq 0 && "$REAL_USER" != "root" ]]; then
+        if ! mv -- "$tmp" "$dest"; then
+            rm -f -- "$tmp"
+            return 1
+        fi
+        chown "$REAL_USER:$REAL_GROUP" "$dest"
+    elif ! user_do mv -- "$tmp" "$dest"; then
+        rm -f -- "$tmp"
+        return 1
+    fi
+
     echo -e "${GREEN}✔ Downloaded: $dest${NC}"
     return 0
 }
@@ -475,7 +516,7 @@ install_setupvibe_bin() {
         return 1
     fi
     user_do chmod +x "$REAL_HOME/.setupvibe/bin/sshcopykey"
-    sys_do chown -R "$REAL_USER:$(id -gn $REAL_USER)" "$REAL_HOME/.setupvibe"
+    sys_do chown -R "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.setupvibe"
 }
 
 
@@ -545,14 +586,6 @@ step_2() {
             sys_do mkdir -p /home/linuxbrew/.linuxbrew
             sys_do chown -R "$REAL_USER" /home/linuxbrew/.linuxbrew 2>/dev/null || true
 
-            # Temporarily allow REAL_USER to use sudo without password for Homebrew installation
-            # This is required because the installer checks for sudo even in non-interactive mode
-            if [[ "$REAL_USER" != "root" ]]; then
-                echo "Temporarily allowing $REAL_USER to use sudo without password for Homebrew installation..."
-                echo "$REAL_USER ALL=(ALL) NOPASSWD:ALL" | sys_do tee /etc/sudoers.d/setupvibe-brew > /dev/null
-                sys_do chmod 440 /etc/sudoers.d/setupvibe-brew
-            fi
-
             # Install Homebrew
             if [[ "$REAL_USER" == "root" ]]; then
                 echo -e "${RED}✘ Homebrew cannot be installed as root. Skipping.${NC}"
@@ -561,8 +594,6 @@ step_2() {
                 user_do env NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             fi
 
-            # Cleanup temporary sudoers rule
-            sys_do rm -f /etc/sudoers.d/setupvibe-brew
         fi
 
         # Configure Homebrew PATH in shell profiles
@@ -609,9 +640,9 @@ step_2() {
 
 step_3() {
     if $IS_MACOS; then
-        echo "Installing PHP 8.4 via Homebrew..."
-        brew_cmd install php@8.4
-        brew_cmd link php@8.4 --force --overwrite
+        echo "Installing PHP $PHP_VERSION via Homebrew..."
+        brew_cmd install php
+        brew_cmd link php --force --overwrite
         
         # Install common extensions via PECL
         # NOTE: pecl prompts interactively (e.g. redis asks about igbinary/lzf/
@@ -641,10 +672,10 @@ step_3() {
             sys_do add-apt-repository ppa:ondrej/php -y
         elif $IS_DEBIAN; then
             echo "Using Debian Sury Strategy..."
-            # Sury repo supports Debian stable releases; fall back to bookworm for unsupported codenames
+            # Sury supports Debian 12 (bookworm) and Debian 13 (trixie).
             PHP_CODENAME="$DISTRO_CODENAME"
             case "$DISTRO_CODENAME" in
-                trixie|forky|sid|experimental) PHP_CODENAME="bookworm" ;;
+                forky|sid|experimental) PHP_CODENAME="trixie" ;;
             esac
             install_key "https://packages.sury.org/php/apt.gpg" "/etc/apt/keyrings/php.gpg"
             echo "deb [signed-by=/etc/apt/keyrings/php.gpg] https://packages.sury.org/php/ $PHP_CODENAME main" | sys_do tee /etc/apt/sources.list.d/php.list
@@ -653,14 +684,15 @@ step_3() {
         fi
         
         sys_do apt-get update -qq
-        echo "Installing PHP 8.4 & Core Extensions..."
-        sys_do apt-get install -y php8.4 php8.4-cli php8.4-common php8.4-dev \
-            php8.4-curl php8.4-mbstring php8.4-xml php8.4-bcmath \
-            php8.4-mysql php8.4-pgsql php8.4-sqlite3
+        echo "Installing PHP $PHP_VERSION & Core Extensions..."
+        sys_do apt-get install -y \
+            "php${PHP_VERSION}" "php${PHP_VERSION}-cli" "php${PHP_VERSION}-common" "php${PHP_VERSION}-dev" \
+            "php${PHP_VERSION}-curl" "php${PHP_VERSION}-mbstring" "php${PHP_VERSION}-xml" "php${PHP_VERSION}-bcmath" \
+            "php${PHP_VERSION}-mysql" "php${PHP_VERSION}-pgsql" "php${PHP_VERSION}-sqlite3"
 
-        echo "Installing PHP 8.4 Optional Extensions..."
-        for _ext in php8.4-zip php8.4-intl php8.4-gd php8.4-imagick \
-                    php8.4-redis php8.4-mongodb php8.4-yaml php8.4-xdebug; do
+        echo "Installing PHP $PHP_VERSION Optional Extensions..."
+        for _ext in "php${PHP_VERSION}-zip" "php${PHP_VERSION}-intl" "php${PHP_VERSION}-gd" "php${PHP_VERSION}-imagick" \
+                    "php${PHP_VERSION}-redis" "php${PHP_VERSION}-mongodb" "php${PHP_VERSION}-yaml" "php${PHP_VERSION}-xdebug"; do
             sys_do apt-get install -y "$_ext" 2>/dev/null \
                 || echo -e "${YELLOW}⚠ Optional extension $_ext not available on this distro, skipping.${NC}"
         done
@@ -694,9 +726,9 @@ step_4() {
         # On macOS, use Homebrew for rbenv
         brew_cmd install rbenv ruby-build
         
-        echo "Checking Ruby 3.3.0..."
-        if ! user_do rbenv versions --bare | grep -q "^3.3.0$"; then
-            echo "Compiling Ruby 3.3.0 (this may take a few minutes)..."
+        echo "Checking Ruby $RUBY_VERSION..."
+        if ! user_do rbenv versions --bare | grep -Fxq "$RUBY_VERSION"; then
+            echo "Compiling Ruby $RUBY_VERSION (this may take a few minutes)..."
             # Optimization: Skip documentation and use parallel compilation.
             # Use single quotes for the outer `bash -c` and double quotes for the
             # values so $(...) is evaluated by the inner shell. With the previous
@@ -704,8 +736,8 @@ step_4() {
             # stored literally as "-j$(nproc ...)" and ruby-build ran a broken
             # `make "-j$(nproc" ...`, failing the build (and cascading the Rails
             # install onto system Ruby). Mirrors the Linux path below.
-            user_do bash -c 'export RUBY_CONFIGURE_OPTS="--disable-install-doc"; export MAKE_OPTS="-j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"; rbenv install 3.3.0'
-            user_do rbenv global 3.3.0
+            user_do env RUBY_VERSION="$RUBY_VERSION" bash -c 'export RUBY_CONFIGURE_OPTS="--disable-install-doc"; export MAKE_OPTS="-j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"; rbenv install "$RUBY_VERSION"'
+            user_do rbenv global "$RUBY_VERSION"
         fi
         
         # Initialize rbenv for current session
@@ -717,17 +749,17 @@ step_4() {
         git_ensure "https://github.com/rbenv/rbenv.git" "$REAL_HOME/.rbenv"
         git_ensure "https://github.com/rbenv/ruby-build.git" "$REAL_HOME/.rbenv/plugins/ruby-build"
 
-        sys_do chown -R $REAL_USER:$(id -gn $REAL_USER) "$REAL_HOME/.rbenv"
+        sys_do chown -R "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.rbenv"
         user_do bash -c "cd '$REAL_HOME/.rbenv' && src/configure && make -C src" >/dev/null 2>&1
 
         # Write gemrc to suppress documentation generation for all future gem installs
         user_do bash -c 'echo "gem: --no-document" > "$HOME/.gemrc"'
 
-        echo "Checking Ruby 3.3.0..."
-        if ! user_do bash -c 'export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; rbenv versions --bare | grep -q "^3.3.0$"'; then
-            echo "Compiling Ruby 3.3.0 (this may take a few minutes)..."
+        echo "Checking Ruby $RUBY_VERSION..."
+        if ! user_do env RUBY_VERSION="$RUBY_VERSION" bash -c 'export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; rbenv versions --bare | grep -Fxq "$RUBY_VERSION"'; then
+            echo "Compiling Ruby $RUBY_VERSION (this may take a few minutes)..."
             # Use $HOME/.tmp as TMPDIR to avoid noexec on /tmp (common in cloud VMs)
-            user_do bash -c 'mkdir -p "$HOME/.tmp"; export TMPDIR="$HOME/.tmp"; export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; export RUBY_CONFIGURE_OPTS="--disable-install-doc"; export MAKE_OPTS="-j$(nproc 2>/dev/null || echo 2)"; rbenv install 3.3.0 && rbenv global 3.3.0'
+            user_do env RUBY_VERSION="$RUBY_VERSION" bash -c 'mkdir -p "$HOME/.tmp"; export TMPDIR="$HOME/.tmp"; export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; export RUBY_CONFIGURE_OPTS="--disable-install-doc"; export MAKE_OPTS="-j$(nproc 2>/dev/null || echo 2)"; rbenv install "$RUBY_VERSION" && rbenv global "$RUBY_VERSION"'
         fi
 
         echo "Installing Rails..."
@@ -739,7 +771,7 @@ step_4() {
 step_5() {
     if $IS_MACOS; then
         echo "Setup Python..."
-        brew_cmd install python@3.12
+        brew_cmd install "python@${PYTHON_VERSION}"
         
         echo "Setup uv (Python Package Manager)..."
         if ! command -v uv &> /dev/null; then
@@ -748,8 +780,7 @@ step_5() {
             user_do uv self update
         fi
         
-        GO_VER="1.22.2"
-        echo "Setup Go $GO_VER..."
+        echo "Setup Go $GO_VERSION..."
         brew_cmd install go
         
         echo "Setup Rust..."
@@ -777,14 +808,37 @@ step_5() {
         fi
         export PATH="$REAL_HOME/.local/bin:$PATH"
 
-        GO_VER="1.22.2"
-        echo "Setup Go $GO_VER ($ARCH_GO)..."
-        if [ ! -d "$REAL_HOME/.local/go" ]; then
-            echo "Installing Go to $REAL_HOME/.local/go..."
-            user_do mkdir -p "$REAL_HOME/.local"
-            wget -q "https://go.dev/dl/go${GO_VER}.linux-${ARCH_GO}.tar.gz" -O /tmp/go.tar.gz
-            user_do tar -C "$REAL_HOME/.local" -xzf /tmp/go.tar.gz && rm /tmp/go.tar.gz
+        echo "Setup Go $GO_VERSION ($ARCH_GO)..."
+        INSTALLED_GO_VERSION=""
+        if [ -x "$REAL_HOME/.local/go/bin/go" ]; then
+            INSTALLED_GO_VERSION=$("$REAL_HOME/.local/go/bin/go" version 2>/dev/null | awk '{print $3}')
         fi
+
+        if [[ "$INSTALLED_GO_VERSION" != "go${GO_VERSION}" ]]; then
+            echo "Installing Go $GO_VERSION to $REAL_HOME/.local/go..."
+            case "$ARCH_GO" in
+                amd64) GO_SHA256="5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053" ;;
+                arm64) GO_SHA256="fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49" ;;
+                *)
+                    echo -e "${RED}✘ No Go checksum configured for architecture: $ARCH_GO${NC}"
+                    return 1
+                    ;;
+            esac
+
+            user_do mkdir -p "$REAL_HOME/.local"
+            safe_download "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH_GO}.tar.gz" /tmp/go.tar.gz 10000000 || return 1
+
+            if [[ "$(sha256sum /tmp/go.tar.gz | awk '{print $1}')" != "$GO_SHA256" ]]; then
+                echo -e "${RED}✘ Go archive checksum verification failed.${NC}"
+                rm -f /tmp/go.tar.gz
+                return 1
+            fi
+
+            user_do rm -rf "$REAL_HOME/.local/go"
+            user_do tar -C "$REAL_HOME/.local" -xzf /tmp/go.tar.gz
+            rm -f /tmp/go.tar.gz
+        fi
+        unset INSTALLED_GO_VERSION GO_SHA256
         export PATH="$REAL_HOME/.local/go/bin:$PATH"
 
         echo "Setup Rust..."
@@ -815,7 +869,7 @@ step_6() {
         user_do npm install -g pnpm npm@latest
         
         echo "Installing PM2 & n8n..."
-        user_do npm install -g pm2 @n8n/cli
+        user_do npm install -g pm2 n8n
 
         echo "Setup Bun..."
         user_do curl -fsSL https://bun.sh/install | bash
@@ -837,7 +891,7 @@ step_6() {
         user_do npm install -g pnpm npm@latest
 
         echo "Installing PM2 & n8n..."
-        user_do npm install -g pm2 @n8n/cli
+        user_do npm install -g pm2 n8n
 
         echo "Setup Bun..."
         user_do bash -c "curl -fsSL https://bun.sh/install | bash"
@@ -874,7 +928,7 @@ step_7() {
         elif $IS_DEBIAN; then
             echo "Using Debian Docker Strategy..."
             case "$DISTRO_CODENAME" in
-                trixie|forky|sid|experimental) DOCKER_CODENAME="bookworm" ;;
+                forky|sid|experimental) DOCKER_CODENAME="trixie" ;;
             esac
         fi
 
@@ -912,7 +966,7 @@ step_7() {
     echo "Configuring Portainer..."
     user_do mkdir -p "$REAL_HOME/.setupvibe/portainer_data"
     safe_download https://raw.githubusercontent.com/promovaweb/setupvibe/main/conf/portainer-compose.yml "$REAL_HOME/.setupvibe/portainer-compose.yml"
-    sys_do chown -R "$REAL_USER:$(id -gn $REAL_USER)" "$REAL_HOME/.setupvibe"
+    sys_do chown -R "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.setupvibe"
 
     # Try to start Portainer if docker is running
     if command -v docker &>/dev/null && sys_do docker info &>/dev/null; then
@@ -928,10 +982,10 @@ step_7() {
 
 step_8() {
     echo "Installing Modern Unix Tools via Homebrew..."
-    TOOLS="bat eza zoxide fzf ripgrep fd lazygit lazydocker neovim glow tldr fastfetch duf jq mise"
+    local -a tools=(bat eza zoxide fzf ripgrep fd lazygit lazydocker neovim glow tldr fastfetch duf jq mise)
 
     if $IS_MACOS; then
-        brew_cmd install $TOOLS
+        brew_cmd install "${tools[@]}"
 
         # FZF keybindings setup
         if [ -d "$BREW_PREFIX/opt/fzf" ]; then
@@ -944,7 +998,7 @@ step_8() {
             return 1
         fi
 
-        brew_cmd install $TOOLS || brew_cmd upgrade $TOOLS
+        brew_cmd install "${tools[@]}" || brew_cmd upgrade "${tools[@]}"
 
         # FZF install script path
         local FZF_OPT="/home/linuxbrew/.linuxbrew/opt/fzf"
@@ -1010,7 +1064,7 @@ step_10() {
         return 0
     fi
 
-    echo "Setting up SSH Server and enabling root remote login..."
+    echo "Setting up SSH Server with key-only root access..."
 
     # Install OpenSSH Server
     if ! command -v sshd &> /dev/null; then
@@ -1029,17 +1083,15 @@ step_10() {
         echo "Backed up original sshd_config"
     fi
 
-    # Configure sshd to allow root login
-    echo "Configuring SSH to allow root login..."
-    sys_do sed -i 's/^#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-    sys_do sed -i 's/^PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-    sys_do sed -i 's/^#PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config
-    sys_do sed -i 's/^PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config
-
-    # Allow password authentication
-    echo "Enabling password authentication for SSH..."
-    sys_do sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
-    sys_do sed -i 's/^PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
+    # Keep password authentication for regular users, but never allow root
+    # password login. A drop-in is idempotent and avoids rewriting vendor config.
+    echo "Configuring SSH authentication defaults..."
+    sys_do mkdir -p /etc/ssh/sshd_config.d
+    printf '%s\n' \
+        '# Managed by SetupVibe' \
+        'PermitRootLogin prohibit-password' \
+        'PasswordAuthentication yes' \
+        | sys_do tee /etc/ssh/sshd_config.d/99-setupvibe.conf > /dev/null
 
     # Validate configuration
     if sys_do sshd -t &> /dev/null; then
@@ -1096,14 +1148,14 @@ step_11() {
         git_ensure "https://github.com/zsh-users/zsh-autosuggestions" "$REAL_HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
         git_ensure "https://github.com/zsh-users/zsh-syntax-highlighting" "$REAL_HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
 
-        echo "Installing Nerd Fonts (FiraCode & JetBrains Mono)..."
+        echo "Installing Nerd Fonts $NERD_FONTS_VERSION (FiraCode & JetBrains Mono)..."
         user_do mkdir -p "$REAL_HOME/.local/share/fonts"
-        wget -q --show-progress -O /tmp/FiraCode.zip https://github.com/ryanoasis/nerd-fonts/releases/download/v3.1.1/FiraCode.zip
+        safe_download "https://github.com/ryanoasis/nerd-fonts/releases/download/v${NERD_FONTS_VERSION}/FiraCode.zip" /tmp/FiraCode.zip 1000000 || return 1
         user_do unzip -o -q /tmp/FiraCode.zip -d "$REAL_HOME/.local/share/fonts"
-        wget -q --show-progress -O /tmp/JetBrainsMono.zip https://github.com/ryanoasis/nerd-fonts/releases/download/v3.1.1/JetBrainsMono.zip
+        safe_download "https://github.com/ryanoasis/nerd-fonts/releases/download/v${NERD_FONTS_VERSION}/JetBrainsMono.zip" /tmp/JetBrainsMono.zip 1000000 || return 1
         user_do unzip -o -q /tmp/JetBrainsMono.zip -d "$REAL_HOME/.local/share/fonts"
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/install_manual.sh)"
-        sys_do chown -R $REAL_USER:$REAL_USER "$REAL_HOME/.local"
+        sys_do chown -R "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.local"
         user_do fc-cache -f >/dev/null
 
 
@@ -1120,7 +1172,7 @@ step_11() {
 
         # Linux ZSHRC
         safe_download https://raw.githubusercontent.com/promovaweb/setupvibe/main/conf/zshrc-linux.zsh "$REAL_HOME/.zshrc"
-        sys_do chown $REAL_USER:$REAL_USER "$REAL_HOME/.zshrc"
+        sys_do chown "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.zshrc"
 
         # Ensure ~/.local/bin is in .bashrc so tools like uv are accessible in bash sessions
         if ! grep -q '\.local/bin' "$REAL_HOME/.bashrc" 2>/dev/null; then
@@ -1128,7 +1180,7 @@ step_11() {
         fi
 
         if [ "$SHELL" != "/bin/zsh" ] && [ "$SHELL" != "/usr/bin/zsh" ]; then
-            sys_do chsh -s $(which zsh) $REAL_USER
+            sys_do chsh -s "$(command -v zsh)" "$REAL_USER"
         fi
     fi
 }
@@ -1149,8 +1201,8 @@ step_12() {
             ln -sfn "$REAL_HOME/.tmux/plugins/tpm" /root/.tmux/plugins/tpm 2>/dev/null || true
     fi
 
-    sys_do chown -R $REAL_USER:$(id -gn $REAL_USER) "$REAL_HOME/.tmux" 2>/dev/null || true
-    sys_do chown $REAL_USER:$(id -gn $REAL_USER) "$REAL_HOME/.tmux.conf" 2>/dev/null || true
+    sys_do chown -R "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.tmux" 2>/dev/null || true
+    sys_do chown "$REAL_USER:$REAL_GROUP" "$REAL_HOME/.tmux.conf" 2>/dev/null || true
 
     echo "Restarting tmux to apply new config..."
     user_do pkill -x tmux 2>/dev/null || true
@@ -1162,7 +1214,7 @@ step_13() {
         "agentlytics"
         "@anthropic-ai/claude-code"
         "@openai/codex"
-        "@githubnext/github-copilot-cli"
+        "@github/copilot"
     )
 
     for pkg in "${AI_TOOLS[@]}"; do
@@ -1185,11 +1237,8 @@ step_14() {
         brew_cmd cleanup --prune=all
         brew_cmd autoremove
 
-        echo "Cleaning macOS caches and temp files..."
-        sys_do rm -rf /private/tmp/* 2>/dev/null || true
-        sys_do rm -rf /private/var/folders/*/*/*/com.apple.* 2>/dev/null || true
-        rm -rf "$REAL_HOME/Library/Caches/"* 2>/dev/null || true
-        rm -rf "$REAL_HOME/.Trash/"* 2>/dev/null || true
+        echo "Cleaning SetupVibe temporary files..."
+        rm -f /tmp/FiraCode.zip /tmp/JetBrainsMono.zip /tmp/go.tar.gz /tmp/ctop /tmp/starship 2>/dev/null || true
     else
         echo "Cleaning APT cache and orphaned packages..."
         sys_do apt-get autoremove -y -qq
@@ -1212,10 +1261,10 @@ step_14() {
     echo "Configuring PM2 for auto-startup..."
     if command -v pm2 &>/dev/null; then
         if $IS_MACOS; then
-            user_do pm2 startup launchd -u $REAL_USER --hp $REAL_HOME
+            user_do pm2 startup launchd -u "$REAL_USER" --hp "$REAL_HOME"
             user_do pm2 save
         else
-            user_do pm2 startup systemd -u $REAL_USER --hp $REAL_HOME
+            user_do pm2 startup systemd -u "$REAL_USER" --hp "$REAL_HOME"
             user_do pm2 save
         fi
         echo -e "${GREEN}✔ PM2 configured for auto-startup${NC}"
@@ -1226,7 +1275,7 @@ step_14() {
 
         echo "Downloading PM2 ecosystem configuration..."
         safe_download https://raw.githubusercontent.com/promovaweb/setupvibe/main/conf/ecosystem.config.js "$REAL_HOME/ecosystem.config.js"
-        sys_do chown "$REAL_USER:$(id -gn $REAL_USER)" "$REAL_HOME/ecosystem.config.js"
+        sys_do chown "$REAL_USER:$REAL_GROUP" "$REAL_HOME/ecosystem.config.js"
         
         echo "Starting PM2 applications from ecosystem file..."
         user_do pm2 start "$REAL_HOME/ecosystem.config.js"

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ curl -sSL server.setupvibe.dev | bash -s -- --manager
 | ------------------------------------- | -------------- | ------- |
 | Base system & build tools             | ✔              | ✔       |
 | Homebrew                              | ✔              | ✗       |
-| PHP 8.4 + Composer + Laravel          | ✔              | ✗       |
+| PHP 8.5 + Composer + Laravel          | ✔              | ✗       |
 | Ruby + rbenv + Rails                  | ✔              | ✗       |
 | Go, Rust, Python + uv                 | ✔              | ✗       |
 | Node.js 24 + Bun + PNPM               | ✔              | ✔ (APT) |

--- a/docs/desktop/README.md
+++ b/docs/desktop/README.md
@@ -2,7 +2,7 @@
 
 > Cross-platform development environment setup — v0.41.6
 
-Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: languages (PHP, Ruby, Go, Rust, Python, Node.js), DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
+Cross-platform setup for macOS and Linux desktops. Installs a complete development stack in one command: PHP 8.5, Ruby 3.4.10, Go 1.26.5, Rust, Python, Node.js 24 LTS, DevOps tools, modern Unix utilities, shell, tmux, and AI CLI tools.
 
 ## Documentation
 

--- a/docs/desktop/en/README.md
+++ b/docs/desktop/en/README.md
@@ -48,12 +48,12 @@ The script shows an interactive roadmap and asks for confirmation before startin
 - **macOS:** installs Homebrew if absent, then installs base tools (`wget`, `curl`, `tmux`, `ffmpeg`, `imagemagick`, `openssl`, `readline`, etc.)
 - **Linux:** installs Linuxbrew under `/home/linuxbrew/.linuxbrew`; adds PATH entries to `~/.bashrc`, `~/.profile`, `~/.zshrc`; runs `brew upgrade` if already present
 
-### Step 3 — PHP 8.4 Ecosystem
+### Step 3 — PHP 8.5 Ecosystem
 
 | Component         | macOS                                       | Linux                                                                                               |
 | ----------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| PHP 8.4           | via Homebrew                                | via ondrej/php PPA (Ubuntu) or sury.org (Debian)                                                    |
-| Extensions        | redis, xdebug, imagick via PECL             | php8.4-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
+| PHP 8.5           | via Homebrew                                | via ondrej/php PPA (Ubuntu) or sury.org (Debian)                                                    |
+| Extensions        | redis, xdebug, imagick via PECL             | php8.5-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
 | Composer          | via Homebrew                                | binary to `~/.local/bin/composer`                                                                   |
 | Laravel installer | `composer global require laravel/installer` | same                                                                                                |
 
@@ -63,16 +63,16 @@ The script shows an interactive roadmap and asks for confirmation before startin
 | --------------- | --------------------------- | --------------------------------------- |
 | rbenv           | via Homebrew                | cloned from GitHub to `~/.rbenv`        |
 | ruby-build      | via Homebrew                | cloned to `~/.rbenv/plugins/ruby-build` |
-| Ruby            | 3.3.0 compiled via rbenv    | same                                    |
+| Ruby            | 3.4.10 compiled via rbenv   | same                                    |
 | Bundler + Rails | `gem install bundler rails` | same                                    |
 
 ### Step 5 — Languages
 
 | Language | macOS                      | Linux                                              |
 | -------- | -------------------------- | -------------------------------------------------- |
-| Python 3 | `python@3.12` via Homebrew | via APT (`python3`, `python3-pip`, `python3-venv`) |
+| Python 3 | `python@3.14` via Homebrew | via APT (`python3`, `python3-pip`, `python3-venv`) |
 | uv       | via install script         | same                                               |
-| Go       | via Homebrew               | 1.22.2 binary to `~/.local/go`                     |
+| Go       | via Homebrew               | verified 1.26.5 binary in `~/.local/go`             |
 | Rust     | via rustup                 | same                                               |
 
 ### Step 6 — JavaScript
@@ -82,7 +82,7 @@ The script shows an interactive roadmap and asks for confirmation before startin
 | Node.js 24 | `node@24` via Homebrew    | via NodeSource APT repo |
 | PNPM       | `npm install -g pnpm`     | same                    |
 | PM2        | `npm install -g pm2`      | same                    |
-| n8n        | `npm install -g @n8n/cli` | same                    |
+| n8n        | `npm install -g n8n`       | same                    |
 | Bun        | via install script        | same                    |
 
 ### Step 7 — DevOps
@@ -126,7 +126,7 @@ Installed via Homebrew on both platforms.
 
 - Installs `openssh-server`
 - Enables and starts the `ssh` systemd service
-- Configures `PermitRootLogin yes` and `PasswordAuthentication yes`
+- Configures `PermitRootLogin prohibit-password` and `PasswordAuthentication yes`
 - Backs up original `sshd_config` before modifying
 
 ### Step 11 — Shell (ZSH & Starship)
@@ -134,7 +134,7 @@ Installed via Homebrew on both platforms.
 - Installs ZSH (Linux via APT; already default on macOS)
 - Installs Oh My Zsh (unattended)
 - Clones `zsh-autosuggestions` and `zsh-syntax-highlighting` plugins
-- Installs Nerd Fonts: **FiraCode** and **JetBrains Mono** (Homebrew Cask on macOS; downloaded to `~/.local/share/fonts` on Linux)
+- Installs Nerd Fonts: **FiraCode** and **JetBrains Mono** (Homebrew Cask on macOS; v3.4.0 downloaded to `~/.local/share/fonts` on Linux)
 - Installs Starship prompt and applies the **Gruvbox Rainbow** preset
 - Downloads helper scripts from [`bin/`](../../../bin) to `~/.setupvibe/bin`; see [Executables](../../en/EXECUTABLES.md)
 - Downloads the appropriate `.zshrc`:
@@ -158,13 +158,13 @@ Installed globally via `npm install -g`:
 | Agentlytics        | `agentlytics`                    |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 **Spec-Kit** is installed via `uv tool install specify-cli`. See [SPECKIT.md](SPECKIT.md) for the full Spec-Driven Development guide and aliases.
 
 ### Step 14 — Finalization & Cleanup
 
-**macOS:** `brew cleanup --prune=all`, `brew autoremove`, clears `~/Library/Caches` and `~/.Trash`.
+**macOS:** `brew cleanup --prune=all`, `brew autoremove`, and removes only SetupVibe temporary files.
 
 **Linux:** `apt autoremove`, `apt clean`, removes temp archives and vacuums journal logs; clears `~/.cache/pip`, `~/.cache/composer`, `~/.npm/_npx`, `~/.bundle/cache`.
 

--- a/docs/desktop/es/README.md
+++ b/docs/desktop/es/README.md
@@ -48,12 +48,12 @@ El script muestra una hoja de ruta interactiva y solicita confirmación antes de
 - **macOS:** instala Homebrew si no está presente, luego instala herramientas base (`wget`, `curl`, `tmux`, `ffmpeg`, `imagemagick`, `openssl`, `readline`, etc.)
 - **Linux:** instala Linuxbrew bajo `/home/linuxbrew/.linuxbrew`; agrega entradas PATH a `~/.bashrc`, `~/.profile`, `~/.zshrc`; ejecuta `brew upgrade` si ya está presente
 
-### Paso 3 — Ecosistema PHP 8.4
+### Paso 3 — Ecosistema PHP 8.5
 
 | Componente         | macOS                                       | Linux                                                                                               |
 | ------------------ | ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| PHP 8.4            | vía Homebrew                                | vía PPA ondrej/php (Ubuntu) o sury.org (Debian)                                                    |
-| Extensiones        | redis, xdebug, imagick vía PECL             | php8.4-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
+| PHP 8.5            | vía Homebrew                                | vía PPA ondrej/php (Ubuntu) o sury.org (Debian)                                                    |
+| Extensiones        | redis, xdebug, imagick vía PECL             | php8.5-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
 | Composer          | vía Homebrew                                | binario en `~/.local/bin/composer`                                                                 |
 | Instalador Laravel | `composer global require laravel/installer` | igual                                                                                               |
 
@@ -63,16 +63,16 @@ El script muestra una hoja de ruta interactiva y solicita confirmación antes de
 | --------------- | --------------------------- | --------------------------------------- |
 | rbenv           | vía Homebrew                | clonado de GitHub en `~/.rbenv`         |
 | ruby-build      | vía Homebrew                | clonado en `~/.rbenv/plugins/ruby-build` |
-| Ruby            | 3.3.0 compilado vía rbenv   | igual                                   |
+| Ruby            | 3.4.10 compilado vía rbenv  | igual                                   |
 | Bundler + Rails | `gem install bundler rails` | igual                                   |
 
 ### Paso 5 — Lenguajes
 
 | Lenguaje | macOS                      | Linux                                              |
 | -------- | -------------------------- | -------------------------------------------------- |
-| Python 3 | `python@3.12` vía Homebrew | vía APT (`python3`, `python3-pip`, `python3-venv`) |
+| Python 3 | `python@3.14` vía Homebrew | vía APT (`python3`, `python3-pip`, `python3-venv`) |
 | uv       | vía script de instalación  | igual                                              |
-| Go       | vía Homebrew               | binario 1.22.2 en `~/.local/go`                    |
+| Go       | vía Homebrew               | binario 1.26.5 verificado en `~/.local/go`         |
 | Rust     | vía rustup                 | igual                                              |
 
 ### Paso 6 — JavaScript
@@ -82,7 +82,7 @@ El script muestra una hoja de ruta interactiva y solicita confirmación antes de
 | Node.js 24  | `node@24` vía Homebrew    | vía repositorio APT NodeSource |
 | PNPM        | `npm install -g pnpm`     | igual                   |
 | PM2         | `npm install -g pm2`      | igual                   |
-| n8n         | `npm install -g @n8n/cli` | igual                   |
+| n8n         | `npm install -g n8n`       | igual                   |
 | Bun         | vía script de instalación | igual                   |
 
 ### Paso 7 — DevOps
@@ -125,7 +125,7 @@ Instaladas mediante Homebrew en ambas plataformas.
 
 - Instala `openssh-server`
 - Habilita e inicia el servicio systemd `ssh`
-- Configura `PermitRootLogin yes` y `PasswordAuthentication yes`
+- Configura `PermitRootLogin prohibit-password` y `PasswordAuthentication yes`
 - Realiza copia de seguridad del `sshd_config` original antes de modificar
 
 ### Paso 11 — Shell (ZSH y Starship)
@@ -133,7 +133,7 @@ Instaladas mediante Homebrew en ambas plataformas.
 - Instala ZSH (Linux vía APT; ya por defecto en macOS)
 - Instala Oh My Zsh (sin intervención)
 - Clona los plugins `zsh-autosuggestions` y `zsh-syntax-highlighting`
-- Instala Nerd Fonts: **FiraCode** y **JetBrains Mono** (Homebrew Cask en macOS; descarga a `~/.local/share/fonts` en Linux)
+- Instala Nerd Fonts: **FiraCode** y **JetBrains Mono** (Homebrew Cask en macOS; descarga v3.4.0 a `~/.local/share/fonts` en Linux)
 - Instala el prompt Starship y aplica el preset **Gruvbox Rainbow**
 - Descarga scripts auxiliares desde [`bin/`](../../../bin) a `~/.setupvibe/bin`; consulta [Ejecutables](../../es/EXECUTABLES.md)
 - Descarga el `.zshrc` adecuado:
@@ -157,13 +157,13 @@ Instaladas globalmente a través de `npm install -g`:
 | Agentlytics        | `agentlytics`                    |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 **Spec-Kit** se instala a través de `uv tool install specify-cli`. Consulte [SPECKIT.md](SPECKIT.md) para obtener la guía completa de Spec-Driven Development y los aliases.
 
 ### Paso 14 — Finalización y Limpieza
 
-**macOS:** `brew cleanup --prune=all`, `brew autoremove`, limpia `~/Library/Caches` y `~/.Trash`.
+**macOS:** `brew cleanup --prune=all`, `brew autoremove` y elimina solo los archivos temporales de SetupVibe.
 
 **Linux:** `apt autoremove`, `apt clean`, elimina archivos temporales y limpia logs del journal; limpia `~/.cache/pip`, `~/.cache/composer`, `~/.npm/_npx`, `~/.bundle/cache`.
 

--- a/docs/desktop/fr/README.md
+++ b/docs/desktop/fr/README.md
@@ -48,12 +48,12 @@ Le script affiche une feuille de route interactive et demande confirmation avant
 - **macOS :** installe Homebrew s'il est absent, puis installe les outils de base (`wget`, `curl`, `tmux`, `ffmpeg`, `imagemagick`, `openssl`, `readline`, etc.)
 - **Linux :** installe Linuxbrew sous `/home/linuxbrew/.linuxbrew` ; ajoute les entrées PATH à `~/.bashrc`, `~/.profile`, `~/.zshrc` ; exécute `brew upgrade` s'il est déjà présent
 
-### Étape 3 — Écosystème PHP 8.4
+### Étape 3 — Écosystème PHP 8.5
 
 | Composant          | macOS                                       | Linux                                                                                               |
 | ------------------ | ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| PHP 8.4            | via Homebrew                                | via PPA ondrej/php (Ubuntu) ou sury.org (Debian)                                                    |
-| Extensions         | redis, xdebug, imagick via PECL             | php8.4-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
+| PHP 8.5            | via Homebrew                                | via PPA ondrej/php (Ubuntu) ou sury.org (Debian)                                                    |
+| Extensions         | redis, xdebug, imagick via PECL             | php8.5-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
 | Composer           | via Homebrew                                | binaire dans `~/.local/bin/composer`                                                               |
 | Installateur Laravel | `composer global require laravel/installer` | identique                                                                                           |
 
@@ -63,16 +63,16 @@ Le script affiche une feuille de route interactive et demande confirmation avant
 | --------------- | --------------------------- | --------------------------------------- |
 | rbenv           | via Homebrew                | cloné depuis GitHub vers `~/.rbenv`     |
 | ruby-build      | via Homebrew                | cloné vers `~/.rbenv/plugins/ruby-build` |
-| Ruby            | 3.3.0 compilé via rbenv     | identique                               |
+| Ruby            | 3.4.10 compilé via rbenv    | identique                               |
 | Bundler + Rails | `gem install bundler rails` | identique                               |
 
 ### Étape 5 — Langages
 
 | Langage  | macOS                      | Linux                                              |
 | -------- | -------------------------- | -------------------------------------------------- |
-| Python 3 | `python@3.12` via Homebrew | via APT (`python3`, `python3-pip`, `python3-venv`) |
+| Python 3 | `python@3.14` via Homebrew | via APT (`python3`, `python3-pip`, `python3-venv`) |
 | uv       | via script d'installation  | identique                                          |
-| Go       | via Homebrew               | binaire 1.22.2 vers `~/.local/go`                  |
+| Go       | via Homebrew               | binaire 1.26.5 vérifié dans `~/.local/go`          |
 | Rust     | via rustup                 | identique                                          |
 
 ### Étape 6 — JavaScript
@@ -82,7 +82,7 @@ Le script affiche une feuille de route interactive et demande confirmation avant
 | Node.js 24 | `node@24` via Homebrew    | via dépôt APT NodeSource |
 | PNPM       | `npm install -g pnpm`     | identique               |
 | PM2        | `npm install -g pm2`      | identique               |
-| n8n        | `npm install -g @n8n/cli` | identique               |
+| n8n        | `npm install -g n8n`       | identique               |
 | Bun        | via script d'installation  | identique               |
 
 ### Étape 7 — DevOps
@@ -125,7 +125,7 @@ Installés via Homebrew sur les deux plateformes.
 
 - Installe `openssh-server`
 - Active et démarre le service systemd `ssh`
-- Configure `PermitRootLogin yes` et `PasswordAuthentication yes`
+- Configure `PermitRootLogin prohibit-password` et `PasswordAuthentication yes`
 - Sauvegarde le `sshd_config` original avant modification
 
 ### Étape 11 — Shell (ZSH et Starship)
@@ -133,7 +133,7 @@ Installés via Homebrew sur les deux plateformes.
 - Installe ZSH (Linux via APT ; déjà par défaut sur macOS)
 - Installe Oh My Zsh (sans intervention)
 - Clone les plugins `zsh-autosuggestions` et `zsh-syntax-highlighting`
-- Installe les Nerd Fonts : **FiraCode** et **JetBrains Mono** (Homebrew Cask sur macOS ; téléchargées vers `~/.local/share/fonts` sur Linux)
+- Installe les Nerd Fonts : **FiraCode** et **JetBrains Mono** (Homebrew Cask sur macOS ; v3.4.0 téléchargée vers `~/.local/share/fonts` sur Linux)
 - Installe le prompt Starship et applique le preset **Gruvbox Rainbow**
 - Télécharge les scripts auxiliaires depuis [`bin/`](../../../bin) vers `~/.setupvibe/bin` ; consultez [Exécutables](../../fr/EXECUTABLES.md)
 - Télécharge le `.zshrc` approprié :
@@ -157,13 +157,13 @@ Installés globalement via `npm install -g` :
 | Agentlytics        | `agentlytics`                    |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 **Spec-Kit** est installé via `uv tool install specify-cli`. Consultez [SPECKIT.md](SPECKIT.md) pour le guide complet du Spec-Driven Development et les alias.
 
 ### Étape 14 — Finalisation et Nettoyage
 
-**macOS :** `brew cleanup --prune=all`, `brew autoremove`, vide `~/Library/Caches` et `~/.Trash`.
+**macOS :** `brew cleanup --prune=all`, `brew autoremove` et supprime uniquement les fichiers temporaires de SetupVibe.
 
 **Linux :** `apt autoremove`, `apt clean`, supprime les archives temporaires et nettoie les logs journal ; vide `~/.cache/pip`, `~/.cache/composer`, `~/.npm/_npx`, `~/.bundle/cache`.
 

--- a/docs/desktop/pt-br/README.md
+++ b/docs/desktop/pt-br/README.md
@@ -48,12 +48,12 @@ O script exibe um roteiro interativo e solicita confirmação antes de iniciar. 
 - **macOS:** instala o Homebrew se ausente, depois instala ferramentas base (`wget`, `curl`, `tmux`, `ffmpeg`, `imagemagick`, `openssl`, `readline`, etc.)
 - **Linux:** instala o Linuxbrew em `/home/linuxbrew/.linuxbrew`; adiciona entradas de PATH ao `~/.bashrc`, `~/.profile`, `~/.zshrc`; executa `brew upgrade` se já presente
 
-### Etapa 3 — Ecossistema PHP 8.4
+### Etapa 3 — Ecossistema PHP 8.5
 
 | Componente          | macOS                                       | Linux                                                                                               |
 | ------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| PHP 8.4             | via Homebrew                                | via PPA ondrej/php (Ubuntu) ou sury.org (Debian)                                                    |
-| Extensões           | redis, xdebug, imagick via PECL             | php8.4-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
+| PHP 8.5             | via Homebrew                                | via PPA ondrej/php (Ubuntu) ou sury.org (Debian)                                                    |
+| Extensões           | redis, xdebug, imagick via PECL             | php8.5-{curl,mbstring,xml,zip,bcmath,intl,mysql,pgsql,sqlite3,gd,imagick,redis,mongodb,yaml,xdebug} |
 | Composer            | via Homebrew                                | binário em `~/.local/bin/composer`                                                                  |
 | Laravel installer   | `composer global require laravel/installer` | igual                                                                                               |
 
@@ -63,16 +63,16 @@ O script exibe um roteiro interativo e solicita confirmação antes de iniciar. 
 | --------------- | --------------------------- | --------------------------------------- |
 | rbenv           | via Homebrew                | clonado do GitHub em `~/.rbenv`         |
 | ruby-build      | via Homebrew                | clonado em `~/.rbenv/plugins/ruby-build` |
-| Ruby            | 3.3.0 compilado via rbenv   | igual                                   |
+| Ruby            | 3.4.10 compilado via rbenv  | igual                                   |
 | Bundler + Rails | `gem install bundler rails` | igual                                   |
 
 ### Etapa 5 — Linguagens
 
 | Linguagem | macOS                      | Linux                                              |
 | --------- | -------------------------- | -------------------------------------------------- |
-| Python 3  | `python@3.12` via Homebrew | via APT (`python3`, `python3-pip`, `python3-venv`) |
+| Python 3  | `python@3.14` via Homebrew | via APT (`python3`, `python3-pip`, `python3-venv`) |
 | uv        | via script de instalação   | igual                                              |
-| Go        | via Homebrew               | binário 1.22.2 em `~/.local/go`                    |
+| Go        | via Homebrew               | binário 1.26.5 verificado em `~/.local/go`         |
 | Rust      | via rustup                 | igual                                              |
 
 ### Etapa 6 — JavaScript
@@ -82,7 +82,7 @@ O script exibe um roteiro interativo e solicita confirmação antes de iniciar. 
 | Node.js 24 | `node@24` via Homebrew    | via repositório APT NodeSource |
 | PNPM       | `npm install -g pnpm`     | igual                   |
 | PM2        | `npm install -g pm2`      | igual                   |
-| n8n        | `npm install -g @n8n/cli` | igual                   |
+| n8n        | `npm install -g n8n`       | igual                   |
 | Bun        | via script de instalação  | igual                   |
 
 ### Etapa 7 — DevOps
@@ -126,7 +126,7 @@ Instaladas via Homebrew em ambas as plataformas.
 
 - Instala `openssh-server`
 - Habilita e inicia o serviço systemd `ssh`
-- Configura `PermitRootLogin yes` e `PasswordAuthentication yes`
+- Configura `PermitRootLogin prohibit-password` e `PasswordAuthentication yes`
 - Faz backup do `sshd_config` original antes de modificar
 
 ### Etapa 11 — Shell (ZSH e Starship)
@@ -134,7 +134,7 @@ Instaladas via Homebrew em ambas as plataformas.
 - Instala ZSH (Linux via APT; já padrão no macOS)
 - Instala Oh My Zsh (sem interação)
 - Clona os plugins `zsh-autosuggestions` e `zsh-syntax-highlighting`
-- Instala Nerd Fonts: **FiraCode** e **JetBrains Mono** (Homebrew Cask no macOS; baixadas em `~/.local/share/fonts` no Linux)
+- Instala Nerd Fonts: **FiraCode** e **JetBrains Mono** (Homebrew Cask no macOS; v3.4.0 baixada em `~/.local/share/fonts` no Linux)
 - Instala o prompt Starship e aplica o preset **Gruvbox Rainbow**
 - Baixa scripts auxiliares de [`bin/`](../../../bin) para `~/.setupvibe/bin`; veja [Executáveis](../../pt-br/EXECUTABLES.md)
 - Baixa o `.zshrc` adequado:
@@ -158,13 +158,13 @@ Instaladas globalmente via `npm install -g`:
 | Agentlytics        | `agentlytics`                    |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 O **Spec-Kit** é instalado via `uv tool install specify-cli`. Veja o [SPECKIT.md](SPECKIT.md) para o guia completo de Spec-Driven Development e aliases.
 
 ### Passo 14 — Finalização e Limpeza
 
-**macOS:** `brew cleanup --prune=all`, `brew autoremove`, limpa `~/Library/Caches` e `~/.Trash`.
+**macOS:** `brew cleanup --prune=all`, `brew autoremove` e remove somente arquivos temporários do SetupVibe.
 
 **Linux:** `apt autoremove`, `apt clean`, remove arquivos temporários e limpa logs do journal; limpa `~/.cache/pip`, `~/.cache/composer`, `~/.npm/_npx`, `~/.bundle/cache`.
 

--- a/docs/server/en/README.md
+++ b/docs/server/en/README.md
@@ -139,7 +139,7 @@ Installs **Node.js 24** via NodeSource APT repo, then installs globally via `npm
 | ------------------ | -------------------------------- |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 npm global packages are installed to `~/.npm-global` (configured with `npm config set prefix`) when not running as root.
 

--- a/docs/server/es/README.md
+++ b/docs/server/es/README.md
@@ -140,7 +140,7 @@ Instala **Node.js 24** a través del repositorio APT de NodeSource, luego instal
 | ------------------ | -------------------------------- |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 Los paquetes globales de npm se instalan en `~/.npm-global` (configurado con `npm config set prefix`) cuando no se ejecuta como root.
 

--- a/docs/server/fr/README.md
+++ b/docs/server/fr/README.md
@@ -140,7 +140,7 @@ Installe **Node.js 24** via le dépôt APT NodeSource, puis installe globalement
 | ------------------ | -------------------------------- |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 Les paquets globaux npm sont installés dans `~/.npm-global` (configuré avec `npm config set prefix`) lorsqu'il n'est pas exécuté en tant que root.
 

--- a/docs/server/pt-br/README.md
+++ b/docs/server/pt-br/README.md
@@ -140,7 +140,7 @@ Instala o **Node.js 24** via repositório NodeSource APT, e então instala globa
 | ------------------ | -------------------------------- |
 | Claude Code        | `@anthropic-ai/claude-code`      |
 | OpenAI Codex       | `@openai/codex`                  |
-| GitHub Copilot CLI | `@githubnext/github-copilot-cli` |
+| GitHub Copilot CLI | `@github/copilot`                |
 
 Os pacotes globais do npm são instalados em `~/.npm-global` (configurado com `npm config set prefix`) quando não está rodando como root.
 

--- a/server.sh
+++ b/server.sh
@@ -27,7 +27,6 @@ NC='\033[0m' # No Color
 
 # --- VERSION ---
 VERSION="0.41.6"
-INSTALL_URL="https://server.setupvibe.dev"
 
 # --- ARGUMENT PARSING ---
 SWARM_MANAGER=false
@@ -673,7 +672,7 @@ step_7() {
     AI_TOOLS=(
         "@anthropic-ai/claude-code"
         "@openai/codex"
-        "@githubnext/github-copilot-cli"
+        "@github/copilot"
     )
 
     for pkg in "${AI_TOOLS[@]}"; do


### PR DESCRIPTION
## Summary

- updates Desktop runtimes to PHP 8.5, Ruby 3.4.10, Go 1.26.5, Python 3.14 on macOS, and Nerd Fonts 3.4.0
- replaces deprecated or incorrect npm packages with `@github/copilot` and `n8n`
- verifies the Go archive SHA-256 and upgrades an existing mismatched Go installation
- hardens APT key/source handling, download ownership, SSH root authentication, and cleanup behavior
- removes the temporary unrestricted Linux Homebrew sudoers rule
- uses native Debian 13 repositories and fixes the early macOS `brew_cmd` call

## Impact

Fresh installs receive supported runtimes and safer defaults. Reruns can now upgrade Go, preserve user-managed APT sources and macOS data, and install downloads with the correct real-user ownership.

## Validation

- `bash -n desktop.sh`
- `bash -n server.sh`
- `git diff --check`
- ShellCheck (`--severity=warning`) for `desktop.sh`
- `markdownlint "**/*.md" --ignore node_modules --config .markdownlint.json` across 46 Markdown files
- verified Go version/checksums against `go.dev`, Homebrew formula versions, npm package deprecation metadata, Debian repository indexes, and updated download URLs