### PR TITLE
fix(server): resolve node/npm by absolute path in AI CLI Tools step

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -831,6 +831,8 @@ step_6() {
 
 
 step_7() {
+    local node_bin
+    local node_dir
     local npm_bin
     local npm_path
     local package
@@ -873,25 +875,32 @@ step_7() {
 
     apt_do update -qq
     apt_do install -y --allow-downgrades nodejs
-    node --version | grep -Eq '^v24\.'
-    npm_bin=$(command -v npm)
+
+    # Resolve the just-installed binaries by their dpkg-owned path instead of
+    # relying on `command -v`/PATH lookups: version managers such as nvm, fnm,
+    # volta or asdf commonly place their own node ahead of /usr/bin on PATH,
+    # which would otherwise silently select the wrong Node.js version here.
+    node_bin=$(dpkg -L nodejs | grep -E '/bin/node$' | head -n1)
+    "$node_bin" --version | grep -Eq '^v24\.'
+    npm_bin=$(dpkg -L nodejs | grep -E '/bin/npm$' | head -n1)
+    node_dir=$(dirname "$node_bin")
 
     if [[ "$REAL_USER" != "root" ]]; then
         user_do mkdir -p "$REAL_HOME/.npm-global"
         user_do "$npm_bin" config set prefix "$REAL_HOME/.npm-global"
-        npm_path="$REAL_HOME/.npm-global/bin:$PATH"
+        npm_path="$REAL_HOME/.npm-global/bin:$node_dir:$PATH"
     else
-        npm_path=$PATH
+        npm_path="$node_dir:$PATH"
     fi
 
     # Remove the package deprecated by GitHub before installing its supported replacement.
-    user_do env PATH="$npm_path" "$npm_bin" uninstall -g @githubnext/github-copilot-cli >/dev/null 2>&1 || true
+    user_do env PATH="$npm_path" "$node_bin" "$npm_bin" uninstall -g @githubnext/github-copilot-cli >/dev/null 2>&1 || true
 
     for index in "${!cli_packages[@]}"; do
         package=${cli_packages[$index]}
         command_name=${cli_commands[$index]}
         echo "Installing $package..."
-        user_do env PATH="$npm_path" "$npm_bin" install --global "$package"
+        user_do env PATH="$npm_path" "$node_bin" "$npm_bin" install --global "$package"
         user_do env PATH="$npm_path" "$command_name" --version >/dev/null
     done
 }


### PR DESCRIPTION
## Problema

Na Etapa 7 (`AI CLI Tools`) do `server.sh`, o Node.js 24 é instalado via NodeSource/APT e validado com:

```bash
node --version | grep -Eq '^v24\.'
npm_bin=$(command -v npm)
```

Em máquinas com um gerenciador de versões Node instalado (`nvm`, `fnm`, `volta`, `asdf`), o `bin/` desse gerenciador costuma vir antes de `/usr/bin` no `PATH`. Isso faz `node`/`command -v npm` resolverem para a versão do gerenciador em vez do Node 24 recém-instalado.

Com `set -Eeuo pipefail`, a falha do `grep -Eq` aborta a etapa **sem nenhuma mensagem de erro visível** — o usuário só vê "Step failed" no resumo final, sem pista da causa real. O mesmo problema afeta silenciosamente as instalações seguintes dos pacotes npm (`@anthropic-ai/claude-code`, `@openai/codex`, `@github/copilot`, `skills@latest`), já que o `npm` resolve seu interpretador via shebang `#!/usr/bin/env node`, também sujeito ao `PATH`.

Reportado em #34, encontrado logo após reproduzir #29 / #30 (as duas falhas juntas bloqueiam totalmente uma instalação `--yes` neste tipo de ambiente).

## Correção

Resolve `node`/`npm` pelos caminhos que o `dpkg` efetivamente instalou (`dpkg -L nodejs`), em vez de depender de `command -v`/`PATH`, e invoca o `npm` explicitamente através desse `node` (em vez de confiar no shebang) nas chamadas de instalação/verificação. Assim a etapa fica correta independentemente do que estiver na frente do `PATH`.

Mudança cirúrgica, restrita à função `step_7()` de `server.sh`.

## Ambiente testado

* OS: Debian GNU/Linux 12 (bookworm), container LXC (Proxmox)
* SetupVibe: v0.41.8
* `nvm` com Node v22.23.0 ativo (reproduz o bug antes da correção)

## Test plan

- [x] `bash -n server.sh` — sintaxe ok
- [x] `shellcheck server.sh` — sem warnings novos (0 antes, 0 depois)
- [x] Revisão do diff — mudança restrita a `step_7()`
- [ ] Execução ponta a ponta do instalador em ambiente com `nvm` ativo (não reexecutei o instalador completo neste fork; a lógica replica exatamente o contorno manual que resolveu o problema no ambiente original)

Fixes #34
