### PR TITLE
fix: unbreak desktop.sh on Ubuntu 26.04 (ondrej PPA cascade) and on current starship (`preset --force` removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to **SetupVibe** are documented in this file.
 - Added Moonshot AI's Kimi Code CLI (`@moonshot-ai/kimi-code`) to the Unix Desktop edition's AI CLI Tools step, installed and validated globally via npm alongside Claude Code, Codex, and Copilot CLI.
 - Enabled tmux extended keys (`extended-keys on` and `terminal-features '*:extkeys'`) in both `tmux-desktop.conf` and `tmux-server.conf`, so modifier+key combinations like `Shift+Enter` and `Ctrl+Arrow` reach TUI apps such as Claude Code, Codex, Kimi Code, and Neovim instead of being swallowed by tmux.
 
+### Fixed
+
+- Fixed the Shell step aborting on current starship releases, which removed `--force` from `starship preset` and reject it as an unexpected argument. In the Desktop edition the step died on that line before `.zshrc` was written, leaving the user with no shell configuration at all. `desktop.sh` and `omarchy.sh` no longer pass the flag, and the Desktop and Server editions preserve an existing `~/.config/starship.toml` before clearing it, so the step also succeeds on older starship, which refused to overwrite an existing file.
+- Fixed the Desktop edition adding `ppa:ondrej/php` on Ubuntu releases the PPA does not publish, such as 26.04 (resolute). The unusable source made every later `apt-get update` exit non-zero, marking unrelated steps as failed and leaving the machine with a broken APT source after the run. `desktop.sh` now probes the PPA for the running codename and falls back to the Ubuntu archive when it is absent.
+- Fixed the Server edition destroying a hand-written `~/.config/starship.toml` without a backup, and aborting the whole run on starship releases that refused to overwrite it.
+
 ---
 
 ## [v0.41.10] - 2026-08-03

--- a/desktop.sh
+++ b/desktop.sh
@@ -1542,8 +1542,10 @@ step_11() {
         # `--force` was removed from `starship preset`; passing it aborts the step on
         # current releases. `-o` overwrites on its own, and clearing the target first
         # keeps older starship (which refused to overwrite) working too.
-        if [ -f "$REAL_HOME/.config/starship.toml" ]; then
-            user_do cp "$REAL_HOME/.config/starship.toml" "$REAL_HOME/.config/starship.toml.bak"
+        # Back up once only, like the sshd_config backup below: an unguarded copy would
+        # replace the user's original with our own preset on the second run.
+        if [ -f "$REAL_HOME/.config/starship.toml" ] && [ ! -e "$REAL_HOME/.config/starship.toml.bak" ]; then
+            user_do cp -p -- "$REAL_HOME/.config/starship.toml" "$REAL_HOME/.config/starship.toml.bak"
         fi
         user_do rm -f "$REAL_HOME/.config/starship.toml"
         user_do "$BREW_PREFIX/bin/starship" preset gruvbox-rainbow \
@@ -1586,8 +1588,10 @@ step_11() {
         # `--force` was removed from `starship preset`; passing it aborts the step on
         # current releases. `-o` overwrites on its own, and clearing the target first
         # keeps older starship (which refused to overwrite) working too.
-        if [ -f "$REAL_HOME/.config/starship.toml" ]; then
-            user_do cp "$REAL_HOME/.config/starship.toml" "$REAL_HOME/.config/starship.toml.bak"
+        # Back up once only, like the sshd_config backup below: an unguarded copy would
+        # replace the user's original with our own preset on the second run.
+        if [ -f "$REAL_HOME/.config/starship.toml" ] && [ ! -e "$REAL_HOME/.config/starship.toml.bak" ]; then
+            user_do cp -p -- "$REAL_HOME/.config/starship.toml" "$REAL_HOME/.config/starship.toml.bak"
         fi
         user_do rm -f "$REAL_HOME/.config/starship.toml"
         user_do "$REAL_HOME/.local/bin/starship" preset gruvbox-rainbow \

--- a/desktop.sh
+++ b/desktop.sh
@@ -1008,7 +1008,14 @@ step_3() {
         echo "Configuring PHP Repository..."
         if $IS_UBUNTU; then
             echo "Using Ubuntu PPA Strategy..."
-            sys_do add-apt-repository ppa:ondrej/php -y
+            # Only add the PPA when it actually publishes this Ubuntu codename.
+            # Newer releases (e.g. 26.04 resolute) ship PHP in the main archive while
+            # the PPA 404s, and the leftover source then breaks every later apt-get update.
+            if curl -fsI "https://ppa.launchpadcontent.net/ondrej/php/ubuntu/dists/${DISTRO_CODENAME}/Release" >/dev/null 2>&1; then
+                sys_do add-apt-repository ppa:ondrej/php -y
+            else
+                echo -e "${YELLOW}⚠ ondrej/php has no build for ${DISTRO_CODENAME}; using the Ubuntu archive.${NC}"
+            fi
         elif $IS_DEBIAN; then
             echo "Using Debian Sury Strategy..."
             # Sury supports Debian 12 (bookworm) and Debian 13 (trixie).
@@ -1532,8 +1539,15 @@ step_11() {
         user_do mkdir -p "$REAL_HOME/.config"
 
         echo "Applying Starship Preset: Gruvbox Rainbow..."
+        # `--force` was removed from `starship preset`; passing it aborts the step on
+        # current releases. `-o` overwrites on its own, and clearing the target first
+        # keeps older starship (which refused to overwrite) working too.
+        if [ -f "$REAL_HOME/.config/starship.toml" ]; then
+            user_do cp "$REAL_HOME/.config/starship.toml" "$REAL_HOME/.config/starship.toml.bak"
+        fi
+        user_do rm -f "$REAL_HOME/.config/starship.toml"
         user_do "$BREW_PREFIX/bin/starship" preset gruvbox-rainbow \
-            --force -o "$REAL_HOME/.config/starship.toml"
+            -o "$REAL_HOME/.config/starship.toml"
         perl -i -pe 's/╭/┌/g; s/╰/└/g; s/\x{e0b6}/\x{e0b2}/g; s/\x{e0b4}/\x{e0b0}/g' "$REAL_HOME/.config/starship.toml"
 
         # macOS ZSHRC
@@ -1569,8 +1583,15 @@ step_11() {
         user_do mkdir -p "$REAL_HOME/.config"
 
         echo "Applying Starship Preset: Gruvbox Rainbow..."
+        # `--force` was removed from `starship preset`; passing it aborts the step on
+        # current releases. `-o` overwrites on its own, and clearing the target first
+        # keeps older starship (which refused to overwrite) working too.
+        if [ -f "$REAL_HOME/.config/starship.toml" ]; then
+            user_do cp "$REAL_HOME/.config/starship.toml" "$REAL_HOME/.config/starship.toml.bak"
+        fi
+        user_do rm -f "$REAL_HOME/.config/starship.toml"
         user_do "$REAL_HOME/.local/bin/starship" preset gruvbox-rainbow \
-            --force -o "$REAL_HOME/.config/starship.toml"
+            -o "$REAL_HOME/.config/starship.toml"
         perl -i -pe 's/╭/┌/g; s/╰/└/g; s/\x{e0b6}/\x{e0b2}/g; s/\x{e0b4}/\x{e0b0}/g' "$REAL_HOME/.config/starship.toml"
 
         # Linux ZSHRC

--- a/omarchy.sh
+++ b/omarchy.sh
@@ -371,7 +371,9 @@ write_starship_config() {
 
     user_do mkdir -p "$setupvibe_dir"
     if [[ ! -f "$starship_config" ]]; then
-        user_do starship preset gruvbox-rainbow --force -o "$starship_config"
+        # `--force` was removed from `starship preset` and now aborts the step; the
+        # `! -f` guard above already means there is nothing to overwrite.
+        user_do starship preset gruvbox-rainbow -o "$starship_config"
         user_do sed -i 's/╭/┌/g; s/╰/└/g; s///g; s///g' "$starship_config"
     else
         echo "Configuração Starship do SetupVibe já existe; mantendo personalizações."

--- a/server.sh
+++ b/server.sh
@@ -832,6 +832,11 @@ step_5() {
     user_do mkdir -p "$REAL_HOME/.config"
 
     echo "Applying Starship Preset: Gruvbox Rainbow..."
+    # Older starship refuses to overwrite an existing config and, under `set -e`, that
+    # aborts the whole run; current starship overwrites it silently and destroys a
+    # hand-written config. Preserve it once, then clear the target so both behave.
+    backup_file_once "$REAL_HOME/.config/starship.toml"
+    user_do rm -f "$REAL_HOME/.config/starship.toml"
     user_do "$starship_bin" preset gruvbox-rainbow -o "$REAL_HOME/.config/starship.toml"
     user_do sed -i 's/╭/┌/g; s/╰/└/g' "$REAL_HOME/.config/starship.toml"
 


### PR DESCRIPTION
Fixes two independent failures that I hit running `desktop.sh` v0.41.11 on **Ubuntu 26.04 LTS (resolute)** with **starship 1.25.0**. Together they turned the run into 4 failed steps out of 14; with this patch the same machine gets **14/14 ✔ OK**.

Closes #43 · addresses the `ondrej/php` half of #36 (and #40) · also fixes the data-loss reported in #29 / #30.

---

## 1. `starship preset --force` is no longer a valid argument

`--force` was removed from `starship preset`. On current releases it aborts:

```
error: unexpected argument '--force' found
NOTE: passed arguments: ["preset", "gruvbox-rainbow", "--force", "-o", ".../starship.toml"]
```

**Why it's worse than one failed step.** Under `set -e` the step dies on that exact line — which sits immediately *before* the `.zshrc` is written:

```bash
user_do "$REAL_HOME/.local/bin/starship" preset gruvbox-rainbow \
    --force -o "$REAL_HOME/.config/starship.toml"      # <- dies here
perl -i -pe '...' "$REAL_HOME/.config/starship.toml"

# Linux ZSHRC
safe_download .../conf/zshrc-linux.zsh "$REAL_HOME/.zshrc"   # <- never runs
```

So the user ends up with **no `.zshrc`, no `.zshrc.local` and no Starship config**, while the summary shows what looks like one isolated failure.

**Why not just delete the flag.** `--force` was added to satisfy #29 / #30, where *older* starship refused to overwrite an existing `starship.toml` (its error message literally said `use --force to overwrite`). Removing it alone would re-break those users. Clearing the target first works on **both** old and new starship, since neither has an existing file to complain about.

The added `cp` also fixes the other half of #29 / #30: today the step **destroys a hand-written `starship.toml` with no backup**. Now it is preserved as `starship.toml.bak`.

`omarchy.sh` only drops the flag — its `if [[ ! -f "$starship_config" ]]` guard already means there is nothing to overwrite there.

## 2. `ppa:ondrej/php` is added even when it has no build for the running codename

```
E: The repository '.../ondrej/php/ubuntu resolute Release' does not have a Release file.
```

The PPA genuinely has no build for this release, and Ubuntu 26.04 ships the target version in `main` anyway:

```console
$ curl -sI https://ppa.launchpadcontent.net/ondrej/php/ubuntu/dists/resolute/Release | head -1
HTTP/2 404

$ apt-cache policy php8.5-cli
  Installed: 8.5.4-0ubuntu1.2
     500 http://archive.ubuntu.com/ubuntu resolute-updates/main amd64 Packages
```

**The cascade is the real damage.** `add-apt-repository` leaves the broken source behind in `/etc/apt/sources.list.d/`, so **every later `apt-get update` in the run exits non-zero** and each step touching APT is marked failed. Steps `[6]` and `[7]` are not independently broken — the logs show the NodeSource and Docker keys installing successfully right before the `E:` line. It also outlives the script: until the file is removed by hand, every `apt update` on the machine keeps erroring.

Probing the dist before adding leaves supported releases completely untouched.

---

## Verification

Run on Ubuntu 26.04 LTS (resolute), kernel 7.0.0-29-generic, starship 1.25.0.

**Before → after on the same machine:**

| Step | before | after |
|---|---|---|
| [3] PHP 8.5 Ecosystem | ✘ Error | ✔ OK |
| [6] JavaScript | ✘ Error | ✔ OK |
| [7] DevOps | ✘ Error | ✔ OK |
| [11] Shell (ZSH & Starship) | ✘ Error | ✔ OK |
| **total** | **4 failed** | **14/14 ✔ OK** |

Step [3] now prints `⚠ ondrej/php has no build for resolute; using the Ubuntu archive.` and installs PHP 8.5.4 + Composer + the Laravel installer normally from the Ubuntu archive. `~/.config/starship.toml` (3876 bytes) and `~/.zshrc` are both written, and `apt update` is clean afterwards.

**No regression for supported releases** — the probe only skips where the PPA really is absent:

```console
codename resolute  -> SKIP (use Ubuntu archive)
codename noble     -> ADD PPA
codename jammy     -> ADD PPA
```

**Starship block, tested standalone:** re-running it is idempotent, and a pre-existing hand-written config is preserved:

```console
new config: 3876 bytes | backup kept: # my hand-written config
2nd run OK (idempotent)
```

`bash -n` passes on both changed scripts.

---

Contribuição do Vitor Canoas — [@vitorcanoas](https://github.com/vitorcanoas) · canoassuporte@gmail.com
Valeu pelo projeto, Luiz! Qualquer ajuste que você preferir na abordagem, é só falar que eu mudo.
