### PR TITLE
fix: resolve Ubuntu 24.04/Noble and Linux Mint compatibility issues

### DIFF
--- a/desktop.sh
+++ b/desktop.sh
@@ -1222,7 +1222,7 @@ step_5() {
 
         echo "Installing Cronboard (Cron TUI)..."
         if ! user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; command -v cronboard" &> /dev/null; then
-            user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv tool install git+https://github.com/antoniorodr/cronboard"
+            user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv tool install --force git+https://github.com/antoniorodr/cronboard"
         fi
 
         cron_ensure
@@ -1322,7 +1322,7 @@ step_7() {
         echo "Configuring Ansible..."
         if $IS_UBUNTU; then
             echo "Using Ubuntu Ansible PPA Strategy..."
-            sys_do add-apt-repository --yes --update ppa:ansible/ansible
+            sys_do add-apt-repository -y ppa:ansible/ansible
             sys_do apt-get install -y ansible
         elif $IS_DEBIAN; then
             echo "Using Debian Ansible Strategy..."
@@ -1684,7 +1684,7 @@ step_13() {
 
     echo "Installing Spec-Kit (specify-cli)..."
     if ! user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; command -v specify" &>/dev/null; then
-        user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv tool install specify-cli"
+        user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv tool install --force specify-cli"
     else
         user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv tool upgrade specify-cli" 2>/dev/null || true
     fi

--- a/desktop.sh
+++ b/desktop.sh
@@ -1146,7 +1146,7 @@ step_5() {
         if ! command -v uv &> /dev/null; then
             user_do curl -LsSf https://astral.sh/uv/install.sh | sh
         else
-            user_do uv self update
+            user_do uv self update 2>/dev/null || true
         fi
         
         echo "Setup Go $GO_VERSION..."
@@ -1175,7 +1175,7 @@ step_5() {
         if ! user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; command -v uv" &> /dev/null; then
             user_do bash -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
         else
-            user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv self update"
+            user_do bash -c "export PATH=\$HOME/.local/bin:\$PATH; uv self update 2>/dev/null || true"
         fi
         export PATH="$REAL_HOME/.local/bin:$PATH"
 

--- a/server.sh
+++ b/server.sh
@@ -713,7 +713,7 @@ step_2() {
     if $IS_UBUNTU; then
         echo "Using the official Ansible Ubuntu PPA..."
         apt_do install -y software-properties-common
-        sys_do add-apt-repository --yes --update ppa:ansible/ansible
+        sys_do add-apt-repository -y ppa:ansible/ansible
         apt_do install -y ansible
     elif $IS_DEBIAN; then
         echo "Using the Debian ansible-core package..."


### PR DESCRIPTION
## Summary of Changes
- **Ubuntu 24.04 / Linux Mint 22 compatibility**: Removed obsolete `--update` flag from `add-apt-repository` in both `desktop.sh` and `server.sh` (on Ubuntu 24.04 `add-apt-repository` no longer accepts `--update` and updates automatically).
- **UV tool installation collision**: Added `--force` to `uv tool install` for `cronboard` and `specify-cli` to avoid fatal exit code 2 when binaries already exist on the target machine.